### PR TITLE
Add tests on Windows & allow manual trigger

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,12 +5,14 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:


### PR DESCRIPTION
Re-adding Windows tests as recommended by @Pike; it was easier to just add Windows to the test matrix.

Also added a `worflow_dispatch` trigger, which'll allow triggering the test suite manually for a branch.