### PR TITLE
Warn about missing placeholders in Android strings.xml translations

### DIFF
--- a/compare_locales/checks/android.py
+++ b/compare_locales/checks/android.py
@@ -251,3 +251,15 @@ def check_params(params, string):
                 "Mismatching formatter",
                 "android"
             )
+    # All parameters used in the reference are expected to be included.
+    # Warn if this isn't the case.
+    for order in params:
+        if order not in sorted(lparams):
+            yield (
+                "warning",
+                0,
+                "Formatter %{}${} not found in translation".format(
+                    order, params[order]
+                ),
+                "android",
+            )

--- a/compare_locales/tests/android/test_checks.py
+++ b/compare_locales/tests/android/test_checks.py
@@ -245,6 +245,25 @@ class PrintfSTest(BaseHelper):
                     "Formatter %2$s not found in reference",
                     "android"
                 ),
+                (
+                    "warning",
+                    0,
+                    "Formatter %1$s not found in translation",
+                    "android"
+                ),
+            )
+        )
+
+    def test_missing_placeholder(self):
+        self._test(
+            ANDROID_WRAPPER % b'"% 1 $ s"',
+            (
+                (
+                    "warning",
+                    0,
+                    "Formatter %1$s not found in translation",
+                    "android"
+                ),
             )
         )
 
@@ -338,6 +357,25 @@ class PrintfDTest(BaseHelper):
                     "error",
                     0,
                     "Formatter %2$d not found in reference",
+                    "android"
+                ),
+                (
+                    "warning",
+                    0,
+                    "Formatter %1$d not found in translation",
+                    "android"
+                ),
+            )
+        )
+
+    def test_missing_placeholder(self):
+        self._test(
+            ANDROID_WRAPPER % b'"% 1 $ d"',
+            (
+                (
+                    "warning",
+                    0,
+                    "Formatter %1$d not found in translation",
                     "android"
                 ),
             )


### PR DESCRIPTION
As discussed on mozilla/pontoon#2323, this adds a warning for Android strings.xml translations when they're missing a formatter defined in a reference. This matches the warnings already emitted for Fluent and .properties files.