### PR TITLE
Drop support for Python 2 & upgrade code style

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/compare_locales/checks/__init__.py
+++ b/compare_locales/checks/__init__.py
@@ -2,9 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 from .base import Checker, EntityPos
 from .android import AndroidChecker
 from .dtd import DTDChecker

--- a/compare_locales/checks/android.py
+++ b/compare_locales/checks/android.py
@@ -2,9 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import re
 from xml.dom import minidom
 
@@ -23,10 +20,7 @@ class AndroidChecker(Checker):
         - tuple of line, column info for the error within the string
         - description string to be shown in the report
         '''
-        for encoding_trouble in super(
-            AndroidChecker, self
-        ).check(refEnt, l10nEnt):
-            yield encoding_trouble
+        yield from super().check(refEnt, l10nEnt)
         refNode = refEnt.node
         l10nNode = l10nEnt.node
         # Apples and oranges, error out.
@@ -38,8 +32,7 @@ class AndroidChecker(Checker):
         if refNode.nodeName != "string":
             yield ("warning", 0, "Unsupported resource type", "android")
             return
-        for report_tuple in self.check_string([refNode], l10nEnt):
-            yield report_tuple
+        yield from self.check_string([refNode], l10nEnt)
 
     def check_string(self, refs, l10nEnt):
         '''Check a single string literal against a list of references.
@@ -79,8 +72,7 @@ class AndroidChecker(Checker):
                 "android"
             )
             return
-        for report_tuple in check_apostrophes(l10nEnt.val):
-            yield report_tuple
+        yield from check_apostrophes(l10nEnt.val)
 
         params, errors = get_params(refs)
         for error, pos in errors:
@@ -91,8 +83,7 @@ class AndroidChecker(Checker):
                 "android"
             )
         if params:
-            for report_tuple in check_params(params, l10nEnt.val):
-                yield report_tuple
+            yield from check_params(params, l10nEnt.val)
 
     def not_translatable(self, *nodes):
         return any(

--- a/compare_locales/checks/base.py
+++ b/compare_locales/checks/base.py
@@ -42,7 +42,7 @@ class Checker:
             yield (
                 "warning",
                 EntityPos(m.start()),
-                "\ufffd in: {}".format(l10nEnt.key),
+                f"\ufffd in: {l10nEnt.key}",
                 "encodings"
             )
 

--- a/compare_locales/checks/base.py
+++ b/compare_locales/checks/base.py
@@ -2,11 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import re
-import six
 
 
 class EntityPos(int):
@@ -16,7 +12,7 @@ class EntityPos(int):
 mochibake = re.compile('\ufffd')
 
 
-class Checker(object):
+class Checker:
     '''Abstract class to implement checks per file type.
     '''
     pattern = None
@@ -57,14 +53,13 @@ class Checker(object):
         self.reference = reference
 
 
-class CSSCheckMixin(object):
+class CSSCheckMixin:
     def maybe_style(self, ref_value, l10n_value):
         ref_map, _ = self.parse_css_spec(ref_value)
         if not ref_map:
             return
         l10n_map, errors = self.parse_css_spec(l10n_value)
-        for t in self.check_style(ref_map, l10n_map, errors):
-            yield t
+        yield from self.check_style(ref_map, l10n_map, errors)
 
     def check_style(self, ref_map, l10n_map, errors):
         if not l10n_map:
@@ -83,7 +78,7 @@ class CSSCheckMixin(object):
                 if unit != ref_unit:
                     msgs.append("units for %s don't match "
                                 "(%s != %s)" % (prop, unit, ref_unit))
-        for prop in six.iterkeys(ref_map):
+        for prop in ref_map.keys():
             msgs.insert(0, '%s only in reference' % prop)
         if msgs:
             yield ('warning', 0, ', '.join(msgs), 'css')

--- a/compare_locales/checks/dtd.py
+++ b/compare_locales/checks/dtd.py
@@ -2,9 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from io import BytesIO
 import re
 from xml import sax
-import six
 
 from compare_locales.parser import DTDParser
 from .base import Checker, CSSCheckMixin
@@ -85,14 +85,14 @@ class DTDChecker(Checker, CSSCheckMixin):
         parser.setContentHandler(self.defaulthandler)
         try:
             parser.parse(
-                six.BytesIO(self.tmpl %
-                            (entities.encode('utf-8'),
-                             refValue.encode('utf-8'))))
+                BytesIO(self.tmpl %
+                        (entities.encode('utf-8'),
+                         refValue.encode('utf-8'))))
             # also catch stray %
             parser.parse(
-                six.BytesIO(self.tmpl %
-                            ((refEnt.all + entities).encode('utf-8'),
-                             b'&%s;' % refEnt.key.encode('utf-8'))))
+                BytesIO(self.tmpl %
+                        ((refEnt.all + entities).encode('utf-8'),
+                         b'&%s;' % refEnt.key.encode('utf-8'))))
         except sax.SAXParseException as e:
             e  # noqa
             yield ('warning',
@@ -108,15 +108,15 @@ class DTDChecker(Checker, CSSCheckMixin):
             self.texthandler.textcontent = ''
             parser.setContentHandler(self.texthandler)
         try:
-            parser.parse(six.BytesIO(self.tmpl % (_entities.encode('utf-8'),
+            parser.parse(BytesIO(self.tmpl % (_entities.encode('utf-8'),
                          l10nValue.encode('utf-8'))))
             # also catch stray %
             # if this fails, we need to substract the entity definition
             parser.setContentHandler(self.defaulthandler)
             parser.parse(
-                six.BytesIO(self.tmpl %
-                            ((l10nEnt.all + _entities).encode('utf-8'),
-                             b'&%s;' % l10nEnt.key.encode('utf-8'))))
+                BytesIO(self.tmpl %
+                        ((l10nEnt.all + _entities).encode('utf-8'),
+                         b'&%s;' % l10nEnt.key.encode('utf-8'))))
         except sax.SAXParseException as e:
             # xml parse error, yield error
             # sometimes, the error is reported on our fake closing

--- a/compare_locales/checks/dtd.py
+++ b/compare_locales/checks/dtd.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import re
 from xml import sax
 import six
@@ -30,10 +28,10 @@ class DTDChecker(Checker, CSSCheckMixin):
     tmpl = b'''<!DOCTYPE elem [%s]>
 <elem>%s</elem>
 '''
-    xmllist = set(('amp', 'lt', 'gt', 'apos', 'quot'))
+    xmllist = {'amp', 'lt', 'gt', 'apos', 'quot'}
 
     def __init__(self, extra_tests, locale=None):
-        super(DTDChecker, self).__init__(extra_tests, locale=locale)
+        super().__init__(extra_tests, locale=locale)
         self.processContent = False
         if self.extra_tests is not None and 'android-dtd' in self.extra_tests:
             self.processContent = True
@@ -49,8 +47,7 @@ class DTDChecker(Checker, CSSCheckMixin):
             else self.entities_for_value(refValue)
 
     def entities_for_value(self, value):
-        reflist = set(m.group(1)
-                      for m in self.eref.finditer(value))
+        reflist = {m.group(1) for m in self.eref.finditer(value)}
         reflist -= self.xmllist
         return reflist
 
@@ -75,10 +72,7 @@ class DTDChecker(Checker, CSSCheckMixin):
 
         Return a checker that offers just those entities.
         """
-        for encoding_trouble in super(
-            DTDChecker, self
-        ).check(refEnt, l10nEnt):
-            yield encoding_trouble
+        yield from super().check(refEnt, l10nEnt)
         refValue, l10nValue = refEnt.raw_val, l10nEnt.raw_val
         # find entities the refValue references,
         # reusing markup from DTDParser.
@@ -141,7 +135,7 @@ class DTDChecker(Checker, CSSCheckMixin):
                     col -= len("<!DOCTYPE elem [")  # first line is DOCTYPE
             yield ('error', (lnr, col), ' '.join(e.args), 'xmlparse')
 
-        warntmpl = u'Referencing unknown entity `%s`'
+        warntmpl = 'Referencing unknown entity `%s`'
         if reflist:
             if inContext:
                 elsewhere = reflist - inContext
@@ -160,7 +154,7 @@ class DTDChecker(Checker, CSSCheckMixin):
             mismatch = sorted(l10nlist - inContext - set(missing))
             for key in mismatch:
                 yield ('warning', (0, 0),
-                       'Entity %s referenced, but %s used in context' % (
+                       'Entity {} referenced, but {} used in context'.format(
                            key,
                            ', '.join(sorted(inContext))
                 ), 'xmlparse')
@@ -173,12 +167,10 @@ class DTDChecker(Checker, CSSCheckMixin):
         if self.length.match(refValue) and not self.length.match(l10nValue):
             yield ('error', 0, 'reference is a CSS length', 'css')
         # Check for actual CSS style attribute values
-        for t in self.maybe_style(refValue, l10nValue):
-            yield t
+        yield from self.maybe_style(refValue, l10nValue)
 
         if self.extra_tests is not None and 'android-dtd' in self.extra_tests:
-            for t in self.processAndroidContent(self.texthandler.textcontent):
-                yield t
+            yield from self.processAndroidContent(self.texthandler.textcontent)
 
     quoted = re.compile("(?P<q>[\"']).*(?P=q)$")
 

--- a/compare_locales/checks/properties.py
+++ b/compare_locales/checks/properties.py
@@ -2,12 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import re
 from difflib import SequenceMatcher
-from six.moves import range
-from six.moves import zip
 
 from compare_locales.parser import PropertiesEntity
 from compare_locales import plurals
@@ -33,10 +29,7 @@ class PropertiesChecker(Checker):
     def check(self, refEnt, l10nEnt):
         '''Test for the different variable formats.
         '''
-        for encoding_trouble in super(
-            PropertiesChecker, self
-        ).check(refEnt, l10nEnt):
-            yield encoding_trouble
+        yield from super().check(refEnt, l10nEnt)
         refValue, l10nValue = refEnt.val, l10nEnt.val
         refSpecs = None
         # check for PluralForm.jsm stuff, should have the docs in the
@@ -47,8 +40,7 @@ class PropertiesChecker(Checker):
                 and 'Localization_and_Plurals' in refEnt.pre_comment.all
                 and refEnt.key != 'pluralRule'
                 and not re.match(r'\d+$', refValue)):
-            for msg_tuple in self.check_plural(refValue, l10nValue):
-                yield msg_tuple
+            yield from self.check_plural(refValue, l10nValue)
             return
         # check for lost escapes
         raw_val = l10nEnt.raw_val
@@ -63,8 +55,7 @@ class PropertiesChecker(Checker):
         except PrintfException:
             refSpecs = []
         if refSpecs:
-            for t in self.checkPrintf(refSpecs, l10nValue):
-                yield t
+            yield from self.checkPrintf(refSpecs, l10nValue)
             return
 
     def check_plural(self, refValue, l10nValue):
@@ -83,12 +74,10 @@ class PropertiesChecker(Checker):
                 yield ('warning', 0, msg, 'plural')
             if expected_forms < found_forms:
                 yield ('warning', 0, msg, 'plural')
-        pats = set(int(m.group(1)) for m in re.finditer('#([0-9]+)',
-                                                        refValue))
+        pats = {int(m.group(1)) for m in re.finditer('#([0-9]+)', refValue)}
         if len(pats) == 0:
             return
-        lpats = set(int(m.group(1)) for m in re.finditer('#([0-9]+)',
-                                                         l10nValue))
+        lpats = {int(m.group(1)) for m in re.finditer('#([0-9]+)', l10nValue)}
         if pats - lpats:
             yield ('warning', 0, 'not all variables used in l10n',
                    'plural')

--- a/compare_locales/commands.py
+++ b/compare_locales/commands.py
@@ -4,8 +4,6 @@
 
 'Commands exposed to commandlines'
 
-from __future__ import absolute_import
-from __future__ import print_function
 import logging
 from argparse import ArgumentParser
 from json import dump as json_dump
@@ -18,7 +16,7 @@ from compare_locales.paths import EnumerateApp, TOMLParser, ConfigNotFound
 from compare_locales.compare import compareProjects
 
 
-class CompareLocales(object):
+class CompareLocales:
     """Check the localization status of gecko applications.
 The first arguments are paths to the l10n.toml or ini files for the
 applications, followed by the base directory of the localization repositories.
@@ -146,7 +144,7 @@ Be careful to specify the right merge directory when using this option.""")
                 l10n_base_dir,
                 quiet=quiet,
                 merge_stage=merge, clobber_merge=clobber)
-        except (OSError, IOError) as exc:
+        except OSError as exc:
             print("FAIL: " + str(exc))
             self.parser.exit(2)
 

--- a/compare_locales/compare/__init__.py
+++ b/compare_locales/compare/__init__.py
@@ -4,8 +4,6 @@
 
 'Mozilla l10n compare locales tool'
 
-from __future__ import absolute_import
-from __future__ import print_function
 import os
 import shutil
 
@@ -54,7 +52,7 @@ def compareProjects(
                                    mergebase=merge_stage)
         if merge_stage is not None:
             if clobber_merge:
-                mergematchers = set(_m.get('merge') for _m in files.matchers)
+                mergematchers = {_m.get('merge') for _m in files.matchers}
                 mergematchers.discard(None)
                 for matcher in mergematchers:
                     clobberdir = matcher.prefix

--- a/compare_locales/compare/content.py
+++ b/compare_locales/compare/content.py
@@ -4,8 +4,6 @@
 
 'Mozilla l10n compare locales tool'
 
-from __future__ import absolute_import
-from __future__ import print_function
 import codecs
 import os
 import shutil
@@ -233,7 +231,7 @@ class ContentComparer:
                             skips.append(l10nent)
                         self.observers.notify(
                             tp, l10n,
-                            u"%s at line %d, column %d for %s" %
+                            "%s at line %d, column %d for %s" %
                             (msg, line, col, refent.key)
                         )
                 pass

--- a/compare_locales/compare/observer.py
+++ b/compare_locales/compare/observer.py
@@ -184,7 +184,7 @@ class ObserverList(Observer):
             'keys',
         )
         leads = [
-            '{:12}'.format(k) for k in keys
+            f'{k:12}' for k in keys
         ]
         out = []
         for locale, summaries in sorted(summaries.items()):

--- a/compare_locales/compare/observer.py
+++ b/compare_locales/compare/observer.py
@@ -4,15 +4,12 @@
 
 'Mozilla l10n compare locales tool'
 
-from __future__ import absolute_import
-from __future__ import print_function
 from collections import defaultdict
-import six
 
 from .utils import Tree
 
 
-class Observer(object):
+class Observer:
 
     def __init__(self, quiet=0, filter=None):
         '''Create Observer
@@ -40,7 +37,7 @@ class Observer(object):
 
     def _dictify(self, d):
         plaindict = {}
-        for k, v in six.iteritems(d):
+        for k, v in d.items():
             plaindict[k] = dict(v)
         return plaindict
 
@@ -61,7 +58,7 @@ class Observer(object):
         if (self.filter is not None and
                 self.filter(file, entity='') == 'ignore'):
             return
-        for category, value in six.iteritems(stats):
+        for category, value in stats.items():
             if category == 'errors':
                 # updateStats isn't called with `errors`, but make sure
                 # we handle this if that changes
@@ -104,7 +101,7 @@ class Observer(object):
 
 class ObserverList(Observer):
     def __init__(self, quiet=0):
-        super(ObserverList, self).__init__(quiet=quiet)
+        super().__init__(quiet=quiet)
         self.observers = []
 
     def __iter__(self):
@@ -117,14 +114,14 @@ class ObserverList(Observer):
         """Check observer for the found data, and if it's
         not to ignore, notify stat_observers.
         """
-        rvs = set(
+        rvs = {
             observer.notify(category, file, data)
             for observer in self.observers
-            )
+            }
         if all(rv == 'ignore' for rv in rvs):
             return 'ignore'
         # our return value doesn't count
-        super(ObserverList, self).notify(category, file, data)
+        super().notify(category, file, data)
         rvs.discard('ignore')
         if 'error' in rvs:
             return 'error'
@@ -137,7 +134,7 @@ class ObserverList(Observer):
         """
         for observer in self.observers:
             observer.updateStats(file, stats)
-        super(ObserverList, self).updateStats(file, stats)
+        super().updateStats(file, stats)
 
     def serializeDetails(self):
 
@@ -190,7 +187,7 @@ class ObserverList(Observer):
             '{:12}'.format(k) for k in keys
         ]
         out = []
-        for locale, summaries in sorted(six.iteritems(summaries)):
+        for locale, summaries in sorted(summaries.items()):
             if locale:
                 out.append(locale + ':')
             segment = [''] * len(keys)
@@ -204,9 +201,9 @@ class ObserverList(Observer):
                 if row.strip()
             ]
 
-            total = sum([summaries[-1].get(k, 0)
-                         for k in ['changed', 'unchanged', 'report', 'missing']
-                         ])
+            total = sum(summaries[-1].get(k, 0)
+                        for k in ['changed', 'unchanged', 'report', 'missing']
+                        )
             rate = 0
             if total:
                 rate = (('changed' in summary and summary['changed'] * 100) or

--- a/compare_locales/compare/utils.py
+++ b/compare_locales/compare/utils.py
@@ -4,16 +4,10 @@
 
 'Mozilla l10n compare locales tool'
 
-from __future__ import absolute_import
-from __future__ import print_function
-
-import six
-from six.moves import zip
-
 from compare_locales import paths
 
 
-class Tree(object):
+class Tree:
     def __init__(self, valuetype):
         self.branches = dict()
         self.valuetype = valuetype
@@ -35,7 +29,7 @@ class Tree(object):
         old = None
         new = tuple(parts)
         t = self
-        for k, v in six.iteritems(self.branches):
+        for k, v in self.branches.items():
             for i, part in enumerate(zip(k, parts)):
                 if part[0] != part[1]:
                     i -= 1
@@ -77,8 +71,7 @@ class Tree(object):
             yield (depth, 'value', self.value)
         for key in keys:
             yield (depth, 'key', key)
-            for child in self.branches[key].getContent(depth + 1):
-                yield child
+            yield from self.branches[key].getContent(depth + 1)
 
     def toJSON(self):
         '''
@@ -87,8 +80,8 @@ class Tree(object):
         '''
         if self.value is not None:
             return self.value
-        return dict(('/'.join(key), self.branches[key].toJSON())
-                    for key in self.branches.keys())
+        return {'/'.join(key): self.branches[key].toJSON()
+                for key in self.branches.keys()}
 
     def getStrRows(self):
         def tostr(t):
@@ -102,7 +95,7 @@ class Tree(object):
         return '\n'.join(self.getStrRows())
 
 
-class AddRemove(object):
+class AddRemove:
     def __init__(self):
         self.left = self.right = None
 
@@ -118,7 +111,7 @@ class AddRemove(object):
 
     def __iter__(self):
         # order_map stores index in left and then index in right
-        order_map = dict((item, (i, -1)) for i, item in enumerate(self.left))
+        order_map = {item: (i, -1) for i, item in enumerate(self.left)}
         left_items = set(order_map)
         # as we go through the right side, keep track of which left
         # item we had in right last, and for items not in left,

--- a/compare_locales/integration_tests/test_plurals.py
+++ b/compare_locales/integration_tests/test_plurals.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/compare_locales/integration_tests/test_plurals.py
+++ b/compare_locales/integration_tests/test_plurals.py
@@ -4,8 +4,8 @@
 
 import json
 import unittest
-from six.moves.urllib.error import URLError
-from six.moves.urllib.request import urlopen
+from urllib.error import URLError
+from urllib.request import urlopen
 
 from compare_locales import plurals
 

--- a/compare_locales/keyedtuple.py
+++ b/compare_locales/keyedtuple.py
@@ -15,14 +15,11 @@ sequences check values. Always try our dict cache `__map` first,
 and fall back to the superclass implementation.
 '''
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 
 class KeyedTuple(tuple):
 
     def __new__(cls, iterable):
-        return super(KeyedTuple, cls).__new__(cls, iterable)
+        return super().__new__(cls, iterable)
 
     def __init__(self, iterable):
         self.__map = {}
@@ -37,14 +34,14 @@ class KeyedTuple(tuple):
                 return True
         except TypeError:
             pass
-        return super(KeyedTuple, self).__contains__(key)
+        return super().__contains__(key)
 
     def __getitem__(self, key):
         try:
             key = self.__map[key]
         except (KeyError, TypeError):
             pass
-        return super(KeyedTuple, self).__getitem__(key)
+        return super().__getitem__(key)
 
     def keys(self):
         for value in self:

--- a/compare_locales/lint/cli.py
+++ b/compare_locales/lint/cli.py
@@ -1,8 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import argparse
 import os

--- a/compare_locales/lint/linter.py
+++ b/compare_locales/lint/linter.py
@@ -1,8 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-from __future__ import absolute_import
-from __future__ import unicode_literals
 
 from collections import Counter
 import os
@@ -11,7 +9,7 @@ from compare_locales import parser, checks
 from compare_locales.paths import File, REFERENCE_LOCALE
 
 
-class L10nLinter(object):
+class L10nLinter:
 
     def lint(self, files, get_reference_and_tests):
         results = []
@@ -44,7 +42,7 @@ class L10nLinter(object):
                 yield result
 
 
-class EntityLinter(object):
+class EntityLinter:
     '''Factored out helper to run linters on a single entity.'''
     def __init__(self, current, checker, reference):
         self.key_count = Counter(entity.key for entity in current)

--- a/compare_locales/lint/util.py
+++ b/compare_locales/lint/util.py
@@ -1,8 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-from __future__ import absolute_import
-from __future__ import unicode_literals
 
 from compare_locales import paths
 

--- a/compare_locales/merge.py
+++ b/compare_locales/merge.py
@@ -17,7 +17,7 @@ to newest instead.
 
 from collections import OrderedDict, defaultdict
 from codecs import encode
-import six
+from functools import reduce
 
 
 from compare_locales import parser as cl
@@ -74,7 +74,7 @@ def merge_resources(parser, resources, keep_newest=True):
 
         return (entity.key, entity)
 
-    entities = six.moves.reduce(
+    entities = reduce(
         lambda x, y: merge_two(x, y, keep_newer=keep_newest),
         map(parse_resource, resources))
     return entities.values()
@@ -114,7 +114,7 @@ def merge_two(newer, older, keep_newer=True):
         acc.append(cur)
         return acc
 
-    pruned = six.moves.reduce(prune, contents, [])
+    pruned = reduce(prune, contents, [])
     return OrderedDict(pruned)
 
 

--- a/compare_locales/merge.py
+++ b/compare_locales/merge.py
@@ -140,4 +140,4 @@ def get_older_entity(newer, older, key):
 
 
 def serialize_legacy_resource(entities):
-    return "".join((entity.all for entity in entities))
+    return "".join(entity.all for entity in entities)

--- a/compare_locales/merge.py
+++ b/compare_locales/merge.py
@@ -34,7 +34,7 @@ def merge_channels(name, resources):
         parser = cl.getParser(name)
     except UserWarning:
         raise MergeNotSupportedError(
-            'Unsupported file format ({}).'.format(name))
+            f'Unsupported file format ({name}).')
 
     entities = merge_resources(parser, resources)
     return encode(serialize_legacy_resource(entities), parser.encoding)

--- a/compare_locales/mozpath.py
+++ b/compare_locales/mozpath.py
@@ -8,7 +8,6 @@ path separators (always use forward slashes).
 Also contains a few additional utilities not found in :py:mod:`os.path`.
 '''
 
-from __future__ import absolute_import
 
 import posixpath
 import os

--- a/compare_locales/parser/__init__.py
+++ b/compare_locales/parser/__init__.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import re
 
 from .base import (
@@ -60,7 +58,7 @@ def getParser(path):
             p = entry_point.resolve()()
             if p.use(path):
                 return p
-    except (ImportError, IOError):
+    except (ImportError, OSError):
         pass
     raise UserWarning("Cannot find Parser")
 

--- a/compare_locales/parser/android.py
+++ b/compare_locales/parser/android.py
@@ -10,8 +10,6 @@ As we're using a built-in XML parser underneath, errors on that level
 break the full parsing, and result in a single Junk entry.
 """
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import re
 from xml.dom import minidom
@@ -31,7 +29,7 @@ class AndroidEntity(Entity):
     ):
         # fill out superclass as good as we can right now
         # most span can get modified at endElement
-        super(AndroidEntity, self).__init__(
+        super().__init__(
             ctx, pre_comment, white_space,
             (None, None),
             (None, None),
@@ -85,7 +83,7 @@ class AndroidEntity(Entity):
         return LiteralEntity(self.key, raw_val, ''.join(all))
 
 
-class NodeMixin(object):
+class NodeMixin:
     def __init__(self, all, value):
         self._all_literal = all
         self._val_literal = value
@@ -138,7 +136,7 @@ class DocumentWrapper(NodeMixin, StickyEntry):
 
 class XMLJunk(Junk):
     def __init__(self, all):
-        super(XMLJunk, self).__init__(None, (0, 0))
+        super().__init__(None, (0, 0))
         self._all_literal = all
 
     @property
@@ -179,7 +177,7 @@ class AndroidParser(Parser):
     capabilities = CAN_SKIP
 
     def __init__(self):
-        super(AndroidParser, self).__init__()
+        super().__init__()
         self.last_comment = None
 
     def walk(self, only_localizable=False):

--- a/compare_locales/parser/android.py
+++ b/compare_locales/parser/android.py
@@ -204,7 +204,7 @@ class AndroidParser(Parser):
             for attr_name, attr_value in docElement.attributes.items():
                 yield DocumentWrapper(
                     attr_name,
-                    ' {}="{}"'.format(attr_name, attr_value)
+                    f' {attr_name}="{attr_value}"'
                 )
             yield DocumentWrapper('>', '>')
         child_num = 0

--- a/compare_locales/parser/base.py
+++ b/compare_locales/parser/base.py
@@ -2,16 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import re
 import bisect
 import codecs
 from collections import Counter
 from compare_locales.keyedtuple import KeyedTuple
 from compare_locales.paths import File
-
-import six
 
 __constructors = []
 
@@ -31,7 +27,7 @@ CAN_SKIP = 2
 CAN_MERGE = 4
 
 
-class Entry(object):
+class Entry:
     '''
     Abstraction layer for a localizable entity.
     Currently supported are grammars of the form:
@@ -165,7 +161,7 @@ class LiteralEntity(Entity):
     It's storing string literals for key, raw_val and all instead of spans.
     """
     def __init__(self, key, val, all):
-        super(LiteralEntity, self).__init__(None, None, None, None, None, None)
+        super().__init__(None, None, None, None, None, None)
         self._key = key
         self._raw_val = val
         self._all = all
@@ -187,7 +183,7 @@ class PlaceholderEntity(LiteralEntity):
     """Subclass of Entity to be removed in merges.
     """
     def __init__(self, key):
-        super(PlaceholderEntity, self).__init__(key, "", "\nplaceholder\n")
+        super().__init__(key, "", "\nplaceholder\n")
 
 
 class Comment(Entry):
@@ -221,13 +217,13 @@ class OffsetComment(Comment):
     @property
     def val(self):
         if self._val_cache is None:
-            self._val_cache = ''.join((
+            self._val_cache = ''.join(
                 l[self.comment_offset:] for l in self.all.splitlines(True)
-            ))
+            )
         return self._val_cache
 
 
-class Junk(object):
+class Junk:
     '''
     An almost-Entity, representing junk data that we didn't parse.
     This way, we can signal bad content as stuff we don't understand.
@@ -294,14 +290,14 @@ class BadEntity(ValueError):
     pass
 
 
-class Parser(object):
+class Parser:
     capabilities = CAN_SKIP | CAN_MERGE
     reWhitespace = re.compile('[ \t\r\n]+', re.M)
     Comment = Comment
     # NotImplementedError would be great, but also tedious
     reKey = reComment = None
 
-    class Context(object):
+    class Context:
         "Fixture for content and line numbers"
         def __init__(self, contents):
             self.contents = contents
@@ -332,16 +328,12 @@ class Parser(object):
             file = file.fullpath
         # python 2 has binary input with universal newlines,
         # python 3 doesn't. Let's split code paths
-        if six.PY2:
-            with open(file, 'rbU') as f:
-                self.readContents(f.read())
-        else:
-            with open(
-                file, 'r',
-                encoding=self.encoding, errors='replace',
-                newline=None
-            ) as f:
-                self.readUnicode(f.read())
+        with open(
+            file,
+            encoding=self.encoding, errors='replace',
+            newline=None
+        ) as f:
+            self.readUnicode(f.read())
 
     def readContents(self, contents):
         '''Read contents and create parsing context.

--- a/compare_locales/parser/base.py
+++ b/compare_locales/parser/base.py
@@ -440,4 +440,4 @@ class Parser:
         found = Counter(entity.key for entity in entities)
         for entity_id, cnt in found.items():
             if cnt > 1:
-                yield '{} occurs {} times'.format(entity_id, cnt)
+                yield f'{entity_id} occurs {cnt} times'

--- a/compare_locales/parser/defines.py
+++ b/compare_locales/parser/defines.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import re
 
 from .base import (

--- a/compare_locales/parser/dtd.py
+++ b/compare_locales/parser/dtd.py
@@ -27,11 +27,10 @@ class DTDEntityMixin(object):
         Named (&amp;), decimal (&#38;), and hex (&#x26; and &#x0026;) formats
         are supported. Unknown entities are left intact.
 
-        As of Python 2.7 and Python 3.6 the following 252 named entities are
+        As of Python 3.7 the following 252 named entities are
         recognized and unescaped:
 
-            https://github.com/python/cpython/blob/2.7/Lib/htmlentitydefs.py
-            https://github.com/python/cpython/blob/3.6/Lib/html/entities.py
+            https://github.com/python/cpython/blob/3.7/Lib/html/entities.py
         '''
         return html_unescape(self.raw_val)
 

--- a/compare_locales/parser/dtd.py
+++ b/compare_locales/parser/dtd.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import re
 
 try:
@@ -19,7 +17,7 @@ from .base import (
 )
 
 
-class DTDEntityMixin(object):
+class DTDEntityMixin:
     @property
     def val(self):
         '''Unescape HTML entities into corresponding Unicode characters.
@@ -38,7 +36,7 @@ class DTDEntityMixin(object):
         # DTDChecker already returns tuples of (line, col) positions
         if isinstance(offset, tuple):
             line_pos, col_pos = offset
-            line, col = super(DTDEntityMixin, self).value_position()
+            line, col = super().value_position()
             if line_pos == 1:
                 col = col + col_pos
             else:
@@ -46,7 +44,7 @@ class DTDEntityMixin(object):
                 line += line_pos - 1
             return line, col
         else:
-            return super(DTDEntityMixin, self).value_position(offset)
+            return super().value_position(offset)
 
 
 class DTDEntity(DTDEntityMixin, Entity):
@@ -82,7 +80,7 @@ class DTDParser(Parser):
                       '[ \t\r\n]+SYSTEM[ \t\r\n]+'
                       '(?P<val>\"[^\"]*\"|\'[^\']*\')[ \t\r\n]*>[ \t\r\n]*'
                       '%' + Name + ';'
-                      '(?:[ \t]*(?:' + XmlComment + u'[ \t\r\n]*)*\n?)?')
+                      '(?:[ \t]*(?:' + XmlComment + '[ \t\r\n]*)*\n?)?')
 
     class Comment(Comment):
         @property

--- a/compare_locales/parser/fluent.py
+++ b/compare_locales/parser/fluent.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import re
 
 from fluent.syntax import FluentParser as FTLParser
@@ -28,7 +26,7 @@ class WordCounter(Visitor):
             (ftl.Span, ftl.Annotation, ftl.BaseComment)
         ):
             return
-        super(WordCounter, self).generic_visit(node)
+        super().generic_visit(node)
 
     def visit_SelectExpression(self, node):
         # optimize select expressions to only go through the variants
@@ -160,7 +158,7 @@ class FluentTerm(FluentEntity):
 
 class FluentComment(Comment):
     def __init__(self, ctx, span, entry):
-        super(FluentComment, self).__init__(ctx, span)
+        super().__init__(ctx, span)
         self._val_cache = entry.content
 
 
@@ -168,7 +166,7 @@ class FluentParser(Parser):
     capabilities = CAN_SKIP
 
     def __init__(self):
-        super(FluentParser, self).__init__()
+        super().__init__()
         self.ftl_parser = FTLParser()
 
     def walk(self, only_localizable=False):

--- a/compare_locales/parser/ini.py
+++ b/compare_locales/parser/ini.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import re
 
 from .base import (
@@ -49,10 +47,10 @@ class IniParser(Parser):
         if m:
             return IniSection(ctx, m.span(), m.span('val'))
 
-        return super(IniParser, self).getNext(ctx, offset)
+        return super().getNext(ctx, offset)
 
     def getJunk(self, ctx, offset, *expressions):
         # base.Parser.getNext calls us with self.reKey, self.reComment.
         # Add self.reSection to the end-of-junk expressions
         expressions = expressions + (self.reSection,)
-        return super(IniParser, self).getJunk(ctx, offset, *expressions)
+        return super().getJunk(ctx, offset, *expressions)

--- a/compare_locales/parser/po.py
+++ b/compare_locales/parser/po.py
@@ -7,8 +7,6 @@
 Parses gettext po and pot files.
 """
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import re
 
@@ -20,7 +18,7 @@ from .base import (
 )
 
 
-class PoEntityMixin(object):
+class PoEntityMixin:
 
     @property
     def val(self):
@@ -77,7 +75,7 @@ class PoParser(Parser):
     reListItem = re.compile(r'[ \t\r\n]*"((?:\\[\\trn"]|[^"\n\\])*)"')
 
     def __init__(self):
-        super(PoParser, self).__init__()
+        super().__init__()
 
     def createEntity(self, ctx, m, current_comment, white_space):
         start = cursor = m.start()

--- a/compare_locales/parser/properties.py
+++ b/compare_locales/parser/properties.py
@@ -2,18 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import re
 
 from .base import (
     Entity, OffsetComment, Whitespace,
     Parser
 )
-from six import unichr
 
 
-class PropertiesEntityMixin(object):
+class PropertiesEntityMixin:
     escape = re.compile(r'\\((?P<uni>u[0-9a-fA-F]{1,4})|'
                         '(?P<nl>\n[ \t]*)|(?P<single>.))', re.M)
     known_escapes = {'n': '\n', 'r': '\r', 't': '\t', '\\': '\\'}
@@ -23,7 +20,7 @@ class PropertiesEntityMixin(object):
         def unescape(m):
             found = m.groupdict()
             if found['uni']:
-                return unichr(int(found['uni'][1:], 16))
+                return chr(int(found['uni'][1:], 16))
             if found['nl']:
                 return ''
             return self.known_escapes.get(found['single'], found['single'])

--- a/compare_locales/paths/__init__.py
+++ b/compare_locales/paths/__init__.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 from compare_locales import mozpath
 from .files import ProjectFiles, REFERENCE_LOCALE
 from .ini import (
@@ -24,7 +23,7 @@ __all__ = [
 ]
 
 
-class File(object):
+class File:
 
     def __init__(self, fullpath, file, module=None, locale=None):
         self.fullpath = fullpath

--- a/compare_locales/paths/configparser.py
+++ b/compare_locales/paths/configparser.py
@@ -2,25 +2,23 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 import errno
 import logging
 from compare_locales import mozpath
 from .project import ProjectConfig
 from .matcher import expand
 import pytoml as toml
-import six
 
 
 class ConfigNotFound(EnvironmentError):
     def __init__(self, path):
-        super(ConfigNotFound, self).__init__(
+        super().__init__(
             errno.ENOENT,
             'Configuration file not found',
             path)
 
 
-class ParseContext(object):
+class ParseContext:
     def __init__(self, path, env, ignore_missing_includes):
         self.path = path
         self.env = env
@@ -29,7 +27,7 @@ class ParseContext(object):
         self.pc = ProjectConfig(path)
 
 
-class TOMLParser(object):
+class TOMLParser:
     def parse(self, path, env=None, ignore_missing_includes=False):
         ctx = self.context(
             path, env=env, ignore_missing_includes=ignore_missing_includes
@@ -55,7 +53,7 @@ class TOMLParser(object):
         try:
             with open(ctx.path, 'rb') as fin:
                 ctx.data = toml.load(fin)
-        except (toml.TomlError, IOError):
+        except (toml.TomlError, OSError):
             raise ConfigNotFound(ctx.path)
 
     def processBasePath(self, ctx):
@@ -91,7 +89,7 @@ class TOMLParser(object):
         assert ctx.data is not None
         for data in ctx.data.get('filters', []):
             paths = data['path']
-            if isinstance(paths, six.string_types):
+            if isinstance(paths, str):
                 paths = [paths]
             rule = {
                 "path": paths,

--- a/compare_locales/paths/files.py
+++ b/compare_locales/paths/files.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 import os
 from compare_locales import mozpath
 
@@ -20,7 +19,7 @@ class ConfigList(list):
             self.append(config)
 
 
-class ProjectFiles(object):
+class ProjectFiles:
     '''Iterable object to get all files and tests for a locale and a
     list of ProjectConfigs.
 
@@ -110,8 +109,7 @@ class ProjectFiles(object):
         # a localization vs over the reference. We do that latter
         # when running in validation mode.
         inner = self.iter_locale() if self.locale else self.iter_reference()
-        for t in inner:
-            yield t
+        yield from inner
 
     def iter_locale(self):
         '''Iterate over locale files.'''
@@ -189,8 +187,7 @@ class ProjectFiles(object):
         return os.path.isfile(path)
 
     def _walk(self, base):
-        for d, dirs, files in os.walk(base):
-            yield d, dirs, files
+        yield from os.walk(base)
 
     def match(self, path):
         '''Return the tuple of l10n_path, reference, mergepath, tests

--- a/compare_locales/paths/ini.py
+++ b/compare_locales/paths/ini.py
@@ -2,14 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 from six.moves.configparser import ConfigParser, NoSectionError, NoOptionError
 from collections import defaultdict
 from compare_locales import util, mozpath
 from .project import ProjectConfig
 
 
-class L10nConfigParser(object):
+class L10nConfigParser:
     '''Helper class to gather application information from ini files.
 
     This class is working on synchronous open to read files or web data.
@@ -116,11 +115,9 @@ class L10nConfigParser(object):
         """Iterate over all dirs and base paths for this l10n.ini as well
         as the included ones.
         """
-        for t in self.dirsIter():
-            yield t
+        yield from self.dirsIter()
         for child in self.children:
-            for t in child.directories():
-                yield t
+            yield from child.directories()
 
     def allLocales(self):
         """Return a list of all the locales of this project"""
@@ -164,7 +161,7 @@ class SourceTreeConfigParser(L10nConfigParser):
         self.children.append(cp)
 
 
-class EnumerateApp(object):
+class EnumerateApp:
     reference = 'en-US'
 
     def __init__(self, inipath, l10nbase):

--- a/compare_locales/paths/ini.py
+++ b/compare_locales/paths/ini.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from six.moves.configparser import ConfigParser, NoSectionError, NoOptionError
+from configparser import ConfigParser, NoSectionError, NoOptionError
 from collections import defaultdict
 from compare_locales import util, mozpath
 from .project import ProjectConfig

--- a/compare_locales/paths/matcher.py
+++ b/compare_locales/paths/matcher.py
@@ -269,8 +269,8 @@ class Variable(Node):
 
     def regex_pattern(self, env):
         if self.repeat:
-            return '(?P={})'.format(self.name)
-        return '(?P<{}>{})'.format(self.name, self._pattern_from_env(env))
+            return f'(?P={self.name})'
+        return f'(?P<{self.name}>{self._pattern_from_env(env)})'
 
     def _pattern_from_env(self, env):
         if self.name in env:
@@ -303,7 +303,7 @@ class Variable(Node):
         return env
 
     def __repr__(self):
-        return 'Variable(name="{}")'.format(self.name)
+        return f'Variable(name="{self.name}")'
 
     def __ne__(self, other):
         return not (self == other)
@@ -368,7 +368,7 @@ class Star(Node):
         self.number = number
 
     def regex_pattern(self, env):
-        return '(?P<s{}>[^/]*)'.format(self.number)
+        return f'(?P<s{self.number}>[^/]*)'
 
     def expand(self, env, raise_missing=False):
         return env['s%d' % self.number]
@@ -391,7 +391,7 @@ class Starstar(Star):
         self.suffix = suffix
 
     def regex_pattern(self, env):
-        return '(?P<s{}>.+{})?'.format(self.number, self.suffix)
+        return f'(?P<s{self.number}>.+{self.suffix})?'
 
     def __ne__(self, other):
         return not (self == other)

--- a/compare_locales/paths/matcher.py
+++ b/compare_locales/paths/matcher.py
@@ -2,12 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 import os
 import re
 import itertools
 from compare_locales import mozpath
-import six
 
 
 # Android uses non-standard locale codes, these are the mappings
@@ -19,11 +17,11 @@ ANDROID_LEGACY_MAP = {
 }
 ANDROID_STANDARD_MAP = {
     legacy: standard
-    for standard, legacy in six.iteritems(ANDROID_LEGACY_MAP)
+    for standard, legacy in ANDROID_LEGACY_MAP.items()
 }
 
 
-class Matcher(object):
+class Matcher:
     '''Path pattern matcher
     Supports path matching similar to mozpath.match(), but does
     not match trailing file paths without trailing wildcards.
@@ -194,7 +192,7 @@ class MissingEnvironment(Exception):
     pass
 
 
-class Node(object):
+class Node:
     '''Abstract base class for all nodes in parsed patterns.'''
     def regex_pattern(self, env):
         '''Create a regular expression fragment for this Node.'''
@@ -245,7 +243,7 @@ class Pattern(list, Node):
         return not (self == other)
 
     def __eq__(self, other):
-        if not super(Pattern, self).__eq__(other):
+        if not super().__eq__(other):
             return False
         if other.__class__ == list:
             # good for tests and debugging
@@ -256,7 +254,7 @@ class Pattern(list, Node):
         )
 
 
-class Literal(six.text_type, Node):
+class Literal(str, Node):
     def regex_pattern(self, env):
         return re.escape(self)
 
@@ -399,7 +397,7 @@ class Starstar(Star):
         return not (self == other)
 
     def __eq__(self, other):
-        if not super(Starstar, self).__eq__(other):
+        if not super().__eq__(other):
             return False
         return self.suffix == other.suffix
 
@@ -413,7 +411,7 @@ PATH_SPECIAL = re.compile(
 )
 
 
-class PatternParser(object):
+class PatternParser:
     def __init__(self):
         # Not really initializing anything, just making room for our
         # result and state members.

--- a/compare_locales/paths/project.py
+++ b/compare_locales/paths/project.py
@@ -2,18 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 import re
 from compare_locales import mozpath
 from .matcher import Matcher
-import six
 
 
 class ExcludeError(ValueError):
     pass
 
 
-class ProjectConfig(object):
+class ProjectConfig:
     '''Abstraction of l10n project configuration data.
     '''
 
@@ -144,8 +142,7 @@ class ProjectConfig(object):
         'Recursively get all configs in this project and its children'
         yield self
         for child in self.children:
-            for config in child.configs:
-                yield config
+            yield from child.configs
 
     @property
     def all_locales(self):
@@ -174,7 +171,7 @@ class ProjectConfig(object):
             return 'ignore'
         return rv
 
-    class FilterCache(object):
+    class FilterCache:
         def __init__(self, locale):
             self.locale = locale
             self.rules = []
@@ -204,9 +201,9 @@ class ProjectConfig(object):
             for exclude in self.excludes
         ):
             return
-        actions = set(
+        actions = {
             child._filter(l10n_file, entity=entity)
-            for child in self.children)
+            for child in self.children}
         if 'error' in actions:
             # return early if we know we'll error
             return 'error'
@@ -238,22 +235,20 @@ class ProjectConfig(object):
             for path in rule['path']:
                 _rule = rule.copy()
                 _rule['path'] = Matcher(path, env=self.environ, root=self.root)
-                for __rule in self._compile_rule(_rule):
-                    yield __rule
+                yield from self._compile_rule(_rule)
             return
-        if isinstance(rule['path'], six.string_types):
+        if isinstance(rule['path'], str):
             rule['path'] = Matcher(
                 rule['path'], env=self.environ, root=self.root
             )
         if 'key' not in rule:
             yield rule
             return
-        if not isinstance(rule['key'], six.string_types):
+        if not isinstance(rule['key'], str):
             for key in rule['key']:
                 _rule = rule.copy()
                 _rule['key'] = key
-                for __rule in self._compile_rule(_rule):
-                    yield __rule
+                yield from self._compile_rule(_rule)
             return
         rule = rule.copy()
         key = rule['key']

--- a/compare_locales/serializer.py
+++ b/compare_locales/serializer.py
@@ -22,7 +22,7 @@ we also prune whitespace once more.`
 '''
 
 from codecs import encode
-import six
+from functools import reduce
 
 from compare_locales.merge import merge_resources, serialize_legacy_resource
 from compare_locales.parser import getParser
@@ -134,4 +134,4 @@ def prune_placeholders(entries):
         acc.append(entity)
         return acc
 
-    return six.moves.reduce(prune_whitespace, pruned, [])
+    return reduce(prune_whitespace, pruned, [])

--- a/compare_locales/serializer.py
+++ b/compare_locales/serializer.py
@@ -69,7 +69,7 @@ def serialize(filename, reference, old_l10n, new_data):
     # create new Entities
     # .val can just be "", merge_channels doesn't need that
     new_l10n = []
-    for key, new_raw_val in six.iteritems(new_data):
+    for key, new_raw_val in new_data.items():
         if new_raw_val is None or key not in ref_mapping:
             continue
         ref_ent = ref_mapping[key]

--- a/compare_locales/serializer.py
+++ b/compare_locales/serializer.py
@@ -52,7 +52,7 @@ def serialize(filename, reference, old_l10n, new_data):
         parser = getParser(filename)
     except UserWarning:
         raise SerializationNotSupportedError(
-            'Unsupported file format ({}).'.format(filename))
+            f'Unsupported file format ({filename}).')
     # create template, whitespace and all
     placeholders = [
         placeholder(entry)

--- a/compare_locales/tests/__init__.py
+++ b/compare_locales/tests/__init__.py
@@ -5,7 +5,6 @@
 '''Mixins for parser tests.
 '''
 
-from __future__ import absolute_import
 
 from pkg_resources import resource_string
 import re
@@ -13,7 +12,6 @@ import unittest
 
 from compare_locales import parser
 from compare_locales.checks import getChecker
-import six
 from six.moves import zip_longest
 
 
@@ -46,9 +44,9 @@ class ParserTestMixin():
         entities = list(self.parser.walk())
         for entity, ref in zip_longest(entities, refs):
             self.assertTrue(entity,
-                            'excess reference entity ' + six.text_type(ref))
+                            'excess reference entity ' + str(ref))
             self.assertTrue(ref,
-                            'excess parsed entity ' + six.text_type(entity))
+                            'excess parsed entity ' + str(entity))
             if isinstance(entity, parser.Entity):
                 self.assertEqual(entity.key, ref[0])
                 self.assertEqual(entity.val, ref[1])

--- a/compare_locales/tests/__init__.py
+++ b/compare_locales/tests/__init__.py
@@ -6,13 +6,13 @@
 '''
 
 
+from itertools import zip_longest
 from pkg_resources import resource_string
 import re
 import unittest
 
 from compare_locales import parser
 from compare_locales.checks import getChecker
-from six.moves import zip_longest
 
 
 class ParserTestMixin():

--- a/compare_locales/tests/android/test_checks.py
+++ b/compare_locales/tests/android/test_checks.py
@@ -1,10 +1,7 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 
 from compare_locales.tests import BaseHelper
 from compare_locales.paths import File

--- a/compare_locales/tests/android/test_parser.py
+++ b/compare_locales/tests/android/test_parser.py
@@ -1,10 +1,7 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import unittest
 
 from compare_locales.tests import ParserTestMixin

--- a/compare_locales/tests/dtd/test_checks.py
+++ b/compare_locales/tests/dtd/test_checks.py
@@ -1,18 +1,13 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import unittest
 
 from compare_locales.checks import getChecker
 from compare_locales.parser import getParser, Parser, DTDEntity
 from compare_locales.paths import File
 from compare_locales.tests import BaseHelper
-import six
-from six.moves import range
 
 
 class TestDTDs(BaseHelper):
@@ -33,7 +28,7 @@ class TestDTDs(BaseHelper):
                      'xmlparse'),))
         # make sure we only handle translated entity references
         self._test('''<!ENTITY foo "This is &ƞǿŧ; good">
-'''.encode('utf-8'),
+'''.encode(),
             (('warning', (0, 0), 'Referencing unknown entity `ƞǿŧ`',
               'xmlparse'),))
 
@@ -173,7 +168,7 @@ class TestAndroid(unittest.TestCase):
             ctx, None, None, (0, len(v)), (), (0, len(v)))
 
     def getDTDEntity(self, v):
-        if isinstance(v, six.binary_type):
+        if isinstance(v, bytes):
             v = v.decode('utf-8')
         v = v.replace('"', '&quot;')
         ctx = Parser.Context('<!ENTITY foo "%s">' % v)
@@ -249,7 +244,7 @@ class TestAndroid(unittest.TestCase):
                          (('error', 2, self.quot_msg, 'android'),))
 
         # broken unicode escape
-        l10n = self.getDTDEntity(b"Some broken \u098 unicode")
+        l10n = self.getDTDEntity(br"Some broken \u098 unicode")
         self.assertEqual(tuple(checker.check(ref, l10n)),
                          (('error', 12, 'truncated \\uXXXX escape',
                            'android'),))

--- a/compare_locales/tests/dtd/test_parser.py
+++ b/compare_locales/tests/dtd/test_parser.py
@@ -5,8 +5,6 @@
 '''Tests for the DTD parser.
 '''
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import unittest
 import re
 
@@ -133,7 +131,7 @@ class TestDTD(ParserTestMixin, unittest.TestCase):
         self.assertEqual(len(entities), 4)
 
     def testBOM(self):
-        self._test(u'\ufeff<!ENTITY foo.label "stuff">',
+        self._test('\ufeff<!ENTITY foo.label "stuff">',
                    (('foo.label', 'stuff'),))
 
     def test_trailing_whitespace(self):
@@ -142,7 +140,7 @@ class TestDTD(ParserTestMixin, unittest.TestCase):
 
     def test_unicode_comment(self):
         self._test(b'<!-- \xe5\x8f\x96 -->'.decode('utf-8'),
-                   ((Comment, u'\u53d6'),))
+                   ((Comment, '\u53d6'),))
 
     def test_empty_file(self):
         self._test('', tuple())

--- a/compare_locales/tests/fluent/test_checks.py
+++ b/compare_locales/tests/fluent/test_checks.py
@@ -1,10 +1,7 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import textwrap
 import unittest
 
@@ -246,8 +243,8 @@ class TestTermReference(BaseHelper):
             b'''simple = localized with { -term }''',
             (
                (
-                    u'warning', 26,
-                    u'Obsolete term reference: -term', u'fluent'
+                    'warning', 26,
+                    'Obsolete term reference: -term', 'fluent'
                 ),
             )
         )
@@ -262,8 +259,8 @@ class TestTermReference(BaseHelper):
             '''),
             (
                 (
-                    u'warning', 0,
-                    u'Missing term reference: -term', u'fluent'
+                    'warning', 0,
+                    'Missing term reference: -term', 'fluent'
                 ),
             )
         )

--- a/compare_locales/tests/fluent/test_parser.py
+++ b/compare_locales/tests/fluent/test_parser.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 import unittest
 
 from compare_locales import parser

--- a/compare_locales/tests/lint/test_linter.py
+++ b/compare_locales/tests/lint/test_linter.py
@@ -1,22 +1,19 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 import unittest
 
 from compare_locales.lint import linter
 from compare_locales.parser import base as parser
 
 
-class MockChecker(object):
+class MockChecker:
     def __init__(self, mocked):
         self.results = mocked
 
     def check(self, ent, ref):
-        for r in self.results:
-            yield r
+        yield from self.results
 
 
 class EntityTest(unittest.TestCase):

--- a/compare_locales/tests/lint/test_util.py
+++ b/compare_locales/tests/lint/test_util.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 
 import unittest
 

--- a/compare_locales/tests/merge/test_unknown.py
+++ b/compare_locales/tests/merge/test_unknown.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import unittest
-import six
 
 from compare_locales.merge import merge_channels, MergeNotSupportedError
 
@@ -18,5 +17,5 @@ foo = Foo 1
 foo = Foo 2
 """)
         pattern = r"Unsupported file format \(foo\.unknown\)\."
-        with six.assertRaisesRegex(self, MergeNotSupportedError, pattern):
+        with self.assertRaisesRegex(MergeNotSupportedError, pattern):
             merge_channels(self.name, channels)

--- a/compare_locales/tests/paths/__init__.py
+++ b/compare_locales/tests/paths/__init__.py
@@ -1,12 +1,8 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-
 from collections import defaultdict
-import six
 import tempfile
 from compare_locales.paths import (
     ProjectConfig, File, ProjectFiles, TOMLParser
@@ -15,7 +11,7 @@ from compare_locales import mozpath
 import pytoml as toml
 
 
-class Rooted(object):
+class Rooted:
     def setUp(self):
         # Use tempdir as self.root, that's absolute on all platforms
         self.root = mozpath.normpath(tempfile.gettempdir())
@@ -27,7 +23,7 @@ class Rooted(object):
         return mozpath.relpath(path, self.root)
 
 
-class SetupMixin(object):
+class SetupMixin:
     def setUp(self):
         self.cfg = ProjectConfig(None)
         self.file = File(
@@ -41,7 +37,7 @@ class SetupMixin(object):
         self.cfg.set_locales(['de'])
 
 
-class MockOS(object):
+class MockOS:
     '''Mock `os.path.isfile` and `os.walk` based on a list of files.
     '''
     def __init__(self, root, paths):
@@ -50,7 +46,7 @@ class MockOS(object):
         self.dirs = {}
         if not paths:
             return
-        if isinstance(paths[0], six.string_types):
+        if isinstance(paths[0], str):
             paths = [
                 mozpath.split(path)
                 for path in sorted(paths)
@@ -99,13 +95,12 @@ class MockOS(object):
             yield node.root, subdirs, node.files
         for subdir in subdirs:
             child = node.dirs[subdir]
-            for tpl in child.walk():
-                yield tpl
+            yield from child.walk()
 
 
 class MockProjectFiles(ProjectFiles):
     def __init__(self, mocks, locale, projects, mergebase=None):
-        (super(MockProjectFiles, self)
+        (super()
             .__init__(locale, projects, mergebase=mergebase))
         root = mozpath.commonprefix(mocks)
         files = [mozpath.relpath(f, root) for f in mocks]
@@ -119,8 +114,7 @@ class MockProjectFiles(ProjectFiles):
         root = self.mocks.find(base)
         if not root:
             return
-        for tpl in root.walk():
-            yield tpl
+        yield from root.walk()
 
 
 class MockTOMLParser(TOMLParser):

--- a/compare_locales/tests/paths/test_configparser.py
+++ b/compare_locales/tests/paths/test_configparser.py
@@ -1,11 +1,8 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, unicode_literals
 import unittest
-import six
 
 from . import MockTOMLParser
 from compare_locales.paths.matcher import Matcher
@@ -82,9 +79,9 @@ basepath = "."
                 mozpath.abspath("other-exclude.toml"),
             ]
         )
-        with six.assertRaisesRegex(self, ExcludeError, 'Included configs'):
+        with self.assertRaisesRegex(ExcludeError, 'Included configs'):
             parser.parse("grandparent.toml")
-        with six.assertRaisesRegex(self, ExcludeError, 'Excluded configs'):
+        with self.assertRaisesRegex(ExcludeError, 'Excluded configs'):
             parser.parse("wrapped.toml")
 
     def test_paths(self):

--- a/compare_locales/tests/paths/test_files.py
+++ b/compare_locales/tests/paths/test_files.py
@@ -366,7 +366,7 @@ basepath = "."
         vendor = parser.parse(self.path('/vendor.toml'))
         pc = ProjectFiles(locale, [pontoon, vendor])
         mock_files = [
-            '{}/{}/{}'.format(locale, dir, f)
+            f'{locale}/{dir}/{f}'
             for locale in ('de', 'en', 'gd', 'it')
             for dir, files in (
                 ('firefox', ('home.ftl', 'feature.ftl')),

--- a/compare_locales/tests/paths/test_files.py
+++ b/compare_locales/tests/paths/test_files.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 import unittest
-import mock
+from unittest import mock
 
 from compare_locales.paths import (
     File,

--- a/compare_locales/tests/paths/test_ini.py
+++ b/compare_locales/tests/paths/test_ini.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 import unittest
 
 from . import (

--- a/compare_locales/tests/paths/test_matcher.py
+++ b/compare_locales/tests/paths/test_matcher.py
@@ -1,10 +1,7 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-import six
 import unittest
 
 from compare_locales.paths.matcher import Matcher, ANDROID_STANDARD_MAP
@@ -434,7 +431,7 @@ class TestAndroid(unittest.TestCase):
         # test legacy locale code mapping
         # he <-> iw, id <-> in, yi <-> ji
         one = Matcher('values-{android_locale}/strings.xml')
-        for legacy, standard in six.iteritems(ANDROID_STANDARD_MAP):
+        for legacy, standard in ANDROID_STANDARD_MAP.items():
             self.assertDictEqual(
                 one.match('values-{}/strings.xml'.format(legacy)),
                 {

--- a/compare_locales/tests/paths/test_matcher.py
+++ b/compare_locales/tests/paths/test_matcher.py
@@ -433,7 +433,7 @@ class TestAndroid(unittest.TestCase):
         one = Matcher('values-{android_locale}/strings.xml')
         for legacy, standard in ANDROID_STANDARD_MAP.items():
             self.assertDictEqual(
-                one.match('values-{}/strings.xml'.format(legacy)),
+                one.match(f'values-{legacy}/strings.xml'),
                 {
                     'android_locale': legacy,
                     'locale': standard
@@ -441,7 +441,7 @@ class TestAndroid(unittest.TestCase):
             )
             self.assertEqual(
                 one.with_env({'locale': standard}).prefix,
-                'values-{}/strings.xml'.format(legacy)
+                f'values-{legacy}/strings.xml'
             )
 
 

--- a/compare_locales/tests/paths/test_paths.py
+++ b/compare_locales/tests/paths/test_paths.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 import unittest
 
 from compare_locales.paths import File

--- a/compare_locales/tests/paths/test_project.py
+++ b/compare_locales/tests/paths/test_project.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 import unittest
 
 from compare_locales.paths import ProjectConfig

--- a/compare_locales/tests/po/test_parser.py
+++ b/compare_locales/tests/po/test_parser.py
@@ -1,8 +1,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import unittest
 
 from compare_locales.tests import ParserTestMixin

--- a/compare_locales/tests/properties/test_checks.py
+++ b/compare_locales/tests/properties/test_checks.py
@@ -1,10 +1,7 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 
 from compare_locales.paths import File
 from compare_locales.tests import BaseHelper

--- a/compare_locales/tests/properties/test_merge.py
+++ b/compare_locales/tests/properties/test_merge.py
@@ -1,5 +1,3 @@
-# coding=utf8
-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -25,18 +23,18 @@ foo = Foo 1
 """)
 
     def test_encoding(self):
-        channels = (encode(u"""
+        channels = (encode("""
 foo = Foo 1…
-""", "utf8"), encode(u"""
+""", "utf8"), encode("""
 foo = Foo 2…
 """, "utf8"))
         output = merge_channels(self.name, channels)
-        self.assertEqual(output, encode(u"""
+        self.assertEqual(output, encode("""
 foo = Foo 1…
 """, "utf8"))
 
         u_output = decode(output, "utf8")
-        self.assertEqual(u_output, u"""
+        self.assertEqual(u_output, """
 foo = Foo 1…
 """)
 

--- a/compare_locales/tests/properties/test_parser.py
+++ b/compare_locales/tests/properties/test_parser.py
@@ -1,13 +1,9 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import unittest
 
-from six.moves import zip
 from compare_locales.tests import ParserTestMixin
 from compare_locales.parser import (
     Comment,
@@ -31,9 +27,9 @@ and still has another line coming
 ''', (
             ('one_line', 'This is one line'),
             (Whitespace, '\n'),
-            ('two_line', u'This is the first of two lines'),
+            ('two_line', 'This is the first of two lines'),
             (Whitespace, '\n'),
-            ('one_line_trailing', u'This line ends in \\'),
+            ('one_line_trailing', 'This line ends in \\'),
             (Whitespace, '\n'),
             (Junk, 'and has junk\n'),
             ('two_lines_triple', 'This line is one of two and ends in \\'
@@ -54,11 +50,11 @@ and still has another line coming
     def test_bug121341(self):
         # port of xpcom/tests/unit/test_bug121341.js
         self.parser.readContents(self.resource('bug121341.properties'))
-        ref = ['abc', 'xy', u"\u1234\t\r\n\u00AB\u0001\n",
+        ref = ['abc', 'xy', "\u1234\t\r\n\u00AB\u0001\n",
                "this is multiline property",
-               "this is another multiline property", u"test\u0036",
-               "yet another multiline propery", u"\ttest5\u0020", " test6\t",
-               u"c\uCDEFd", u"\uABCD"]
+               "this is another multiline property", "test\u0036",
+               "yet another multiline propery", "\ttest5\u0020", " test6\t",
+               "c\uCDEFd", "\uABCD"]
         i = iter(self.parser)
         for r, e in zip(ref, i):
             self.assertEqual(e.val, r)

--- a/compare_locales/tests/serializer/__init__.py
+++ b/compare_locales/tests/serializer/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -7,7 +6,7 @@ from compare_locales.parser import getParser
 from compare_locales.serializer import serialize
 
 
-class Helper(object):
+class Helper:
     """Mixin to test serializers.
 
     Reads the reference_content into self.reference, and uses

--- a/compare_locales/tests/serializer/test_android.py
+++ b/compare_locales/tests/serializer/test_android.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/compare_locales/tests/serializer/test_fluent.py
+++ b/compare_locales/tests/serializer/test_fluent.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/compare_locales/tests/serializer/test_properties.py
+++ b/compare_locales/tests/serializer/test_properties.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/compare_locales/tests/test_apps.py
+++ b/compare_locales/tests/test_apps.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import unittest
 import os
 import tempfile

--- a/compare_locales/tests/test_checks.py
+++ b/compare_locales/tests/test_checks.py
@@ -21,7 +21,7 @@ class CSSParserTest(unittest.TestCase):
             'min-width', 'width', 'max-width',
             'min-height', 'height', 'max-height',
         ):
-            refMap, errors = self.mixin.parse_css_spec('{}:1px;'.format(prop))
+            refMap, errors = self.mixin.parse_css_spec(f'{prop}:1px;')
             self.assertDictEqual(
                 refMap, {prop: 'px'}
             )

--- a/compare_locales/tests/test_checks.py
+++ b/compare_locales/tests/test_checks.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 import unittest
 
 from compare_locales.checks.base import CSSCheckMixin

--- a/compare_locales/tests/test_compare.py
+++ b/compare_locales/tests/test_compare.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 import unittest
 
 from compare_locales import compare, paths

--- a/compare_locales/tests/test_defines.py
+++ b/compare_locales/tests/test_defines.py
@@ -1,10 +1,7 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import unittest
 
 from compare_locales.tests import ParserTestMixin, BaseHelper

--- a/compare_locales/tests/test_ini.py
+++ b/compare_locales/tests/test_ini.py
@@ -1,10 +1,7 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 import unittest
 
 from compare_locales.tests import ParserTestMixin, BaseHelper

--- a/compare_locales/tests/test_keyedtuple.py
+++ b/compare_locales/tests/test_keyedtuple.py
@@ -1,10 +1,7 @@
-# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 
 from collections import namedtuple
 import unittest

--- a/compare_locales/tests/test_merge.py
+++ b/compare_locales/tests/test_merge.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 import unittest
 import filecmp
 import os
@@ -16,7 +15,7 @@ from compare_locales.compare.observer import Observer
 from compare_locales import mozpath
 
 
-class ContentMixin(object):
+class ContentMixin:
     extension = None  # OVERLOAD
 
     @property
@@ -303,8 +302,8 @@ eff = effVal""")
                 }},
              'details': {
                  'l10n.properties': [
-                     {'missingEntity': u'foo'},
-                     {'missingEntity': u'eff'}]
+                     {'missingEntity': 'foo'},
+                     {'missingEntity': 'eff'}]
                 }
              })
         mergefile = mozpath.join(self.tmp, "merge", "l10n.properties")
@@ -380,9 +379,9 @@ eff = leffVal
                 }},
              'details': {
                  'l10n.properties': [
-                     {'missingEntity': u'foo'},
-                     {'error': u'argument 1 `S` should be `d` '
-                               u'at line 1, column 7 for bar'}]
+                     {'missingEntity': 'foo'},
+                     {'error': 'argument 1 `S` should be `d` '
+                               'at line 1, column 7 for bar'}]
                 }
              })
         mergefile = mozpath.join(self.tmp, "merge", "l10n.properties")
@@ -424,7 +423,7 @@ eff = leffVal
                 }},
              'details': {
                  'l10n.properties': [
-                     {'obsoleteEntity': u'other'}]
+                     {'obsoleteEntity': 'other'}]
                 }
              })
         mergefile = mozpath.join(self.tmp, "merge", "l10n.properties")
@@ -446,7 +445,7 @@ eff = leffVal
                 {},
              'details': {
                  'l10n.properties': [
-                     {'obsoleteFile': u'error'}]
+                     {'obsoleteFile': 'error'}]
                 }
              })
         mergefile = mozpath.join(self.tmp, "merge", "l10n.properties")
@@ -486,8 +485,8 @@ bar = duplicated bar
                 }},
              'details': {
                  'l10n.properties': [
-                     {'warning': u'foo occurs 2 times'},
-                     {'error': u'bar occurs 2 times'}]
+                     {'warning': 'foo occurs 2 times'},
+                     {'error': 'bar occurs 2 times'}]
                 }
              })
         mergefile = mozpath.join(self.tmp, "merge", "l10n.properties")
@@ -574,8 +573,8 @@ class TestDTD(unittest.TestCase, ContentMixin):
                 }},
              'details': {
                  'l10n.dtd': [
-                     {'missingEntity': u'foo'},
-                     {'missingEntity': u'eff'}]
+                     {'missingEntity': 'foo'},
+                     {'missingEntity': 'eff'}]
                 }
              })
         mergefile = mozpath.join(self.tmp, "merge", "l10n.dtd")
@@ -617,11 +616,11 @@ class TestDTD(unittest.TestCase, ContentMixin):
                 }},
              'details': {
                  'l10n.dtd': [
-                     {'error': u'Unparsed content "<!ENTY bar '
-                               u'\'gimmick\'>\n" '
-                               u'from line 2 column 1 to '
-                               u'line 3 column 1'},
-                     {'missingEntity': u'bar'}]
+                     {'error': 'Unparsed content "<!ENTY bar '
+                               '\'gimmick\'>\n" '
+                               'from line 2 column 1 to '
+                               'line 3 column 1'},
+                     {'missingEntity': 'bar'}]
                 }
              })
         mergefile = mozpath.join(self.tmp, "merge", "l10n.dtd")
@@ -700,8 +699,8 @@ class TestDTD(unittest.TestCase, ContentMixin):
                 }},
              'details': {
                  'l10n.dtd': [
-                     {'warning': u"can't parse en-US value at line 1, "
-                                 u"column 0 for bar"}]
+                     {'warning': "can't parse en-US value at line 1, "
+                                 "column 0 for bar"}]
                 }
              })
         mergefile = mozpath.join(self.tmp, "merge", "l10n.dtd")
@@ -795,8 +794,8 @@ eff = lEff
             {
                 'details': {
                     'l10n.ftl': [
-                        {'missingEntity': u'bar'},
-                        {'missingEntity': u'-baz'},
+                        {'missingEntity': 'bar'},
+                        {'missingEntity': '-baz'},
                     ],
                 },
                 'summary': {
@@ -844,17 +843,17 @@ eff = lEff {
             {
                 'details': {
                     'l10n.ftl': [
-                        {'error': u'Unparsed content "-- Invalid Comment" '
-                                  u'from line 1 column 1 '
-                                  u'to line 1 column 19'},
-                        {'error': u'Unparsed content "bar lBar" '
-                                  u'from line 3 column 1 '
-                                  u'to line 3 column 9'},
-                        {'error': u'Unparsed content "eff = lEff {" '
-                                  u'from line 4 column 1 '
-                                  u'to line 4 column 13'},
-                        {'missingEntity': u'bar'},
-                        {'missingEntity': u'eff'},
+                        {'error': 'Unparsed content "-- Invalid Comment" '
+                                  'from line 1 column 1 '
+                                  'to line 1 column 19'},
+                        {'error': 'Unparsed content "bar lBar" '
+                                  'from line 3 column 1 '
+                                  'to line 3 column 9'},
+                        {'error': 'Unparsed content "eff = lEff {" '
+                                  'from line 4 column 1 '
+                                  'to line 4 column 13'},
+                        {'missingEntity': 'bar'},
+                        {'missingEntity': 'eff'},
                     ],
                 },
                 'summary': {
@@ -954,23 +953,23 @@ baz = Localized { qux }
                     'l10n.ftl': [
                             {
                                 'warning':
-                                    u'Missing message reference: bar '
-                                    u'at line 1, column 1 for foo'
+                                    'Missing message reference: bar '
+                                    'at line 1, column 1 for foo'
                             },
                             {
                                 'warning':
-                                    u'Obsolete message reference: qux '
-                                    u'at line 1, column 19 for foo'
+                                    'Obsolete message reference: qux '
+                                    'at line 1, column 19 for foo'
                             },
                             {
                                 'warning':
-                                    u'Missing message reference: baz '
-                                    u'at line 2, column 1 for bar'
+                                    'Missing message reference: baz '
+                                    'at line 2, column 1 for bar'
                             },
                             {
                                 'warning':
-                                    u'Obsolete message reference: qux '
-                                    u'at line 3, column 19 for baz'
+                                    'Obsolete message reference: qux '
+                                    'at line 3, column 19 for baz'
                             },
                     ],
                 },
@@ -1022,12 +1021,12 @@ eff = lEff
                     'l10n.ftl': [
                             {
                                 'error':
-                                    u'Obsolete attribute: '
+                                    'Obsolete attribute: '
                                     'obsolete at line 2, column 3 for foo'
                             },
                             {
                                 'error':
-                                    u'Missing attribute: tender at line 3,'
+                                    'Missing attribute: tender at line 3,'
                                     ' column 1 for bar',
                             },
                     ],
@@ -1096,7 +1095,7 @@ eff = lEff
             {
                 'details': {
                     'l10n.ftl': [
-                        {'missingEntity': u'-missing'},
+                        {'missingEntity': '-missing'},
                     ],
                 },
                 'summary': {
@@ -1147,11 +1146,11 @@ bar = lBar
                     'l10n.ftl': [
                         {
                             'error':
-                                u'Missing value at line 1, column 1 for foo'
+                                'Missing value at line 1, column 1 for foo'
                         },
                         {
                             'error':
-                                u'Obsolete value at line 3, column 7 for bar',
+                                'Obsolete value at line 3, column 7 for bar',
                         },
                     ]
                 },
@@ -1346,8 +1345,8 @@ bar = duplicated bar
                 }},
              'details': {
                  'l10n.ftl': [
-                     {'warning': u'foo occurs 2 times'},
-                     {'error': u'bar occurs 2 times'}]
+                     {'warning': 'foo occurs 2 times'},
+                     {'error': 'bar occurs 2 times'}]
                 }
              })
         mergefile = mozpath.join(self.tmp, "merge", "l10n.ftl")
@@ -1386,16 +1385,16 @@ bar = duplicated bar
              'details': {
                  'l10n.ftl': [
                      {'warning':
-                      u'Attribute "attr" is duplicated '
-                      u'at line 2, column 5 for foo'
+                      'Attribute "attr" is duplicated '
+                      'at line 2, column 5 for foo'
                       },
                      {'warning':
-                      u'Attribute "attr" is duplicated '
-                      u'at line 3, column 5 for foo'
+                      'Attribute "attr" is duplicated '
+                      'at line 3, column 5 for foo'
                       },
                      {'warning':
-                      u'Attribute "attr" is duplicated '
-                      u'at line 4, column 5 for foo'
+                      'Attribute "attr" is duplicated '
+                      'at line 4, column 5 for foo'
                       },
                   ]
                 }

--- a/compare_locales/tests/test_mozpath.py
+++ b/compare_locales/tests/test_mozpath.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 from compare_locales.mozpath import (
     relpath,
     join,

--- a/compare_locales/tests/test_parser.py
+++ b/compare_locales/tests/test_parser.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 import pkg_resources
 import shutil
 import tempfile

--- a/compare_locales/tests/test_util.py
+++ b/compare_locales/tests/test_util.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 import unittest
 
 from compare_locales import util

--- a/contrib/lang/setup.py
+++ b/contrib/lang/setup.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from setuptools import setup
 
 setup(

--- a/contrib/lang/setup.py
+++ b/contrib/lang/setup.py
@@ -9,7 +9,7 @@ setup(
     author_email="axel@mozilla.com",
     description=".lang parser for compare-locales",
     platforms=["any"],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4',
+    python_requires='>=3.7, <4',
     package_dir={"": "src"},
     packages=['cl_ext', 'cl_ext.lang'],
     install_requires=[

--- a/contrib/lang/src/cl_ext/lang/lang.py
+++ b/contrib/lang/src/cl_ext/lang/lang.py
@@ -1,7 +1,6 @@
 """
 Parser for the .lang translation format.
 """
-from __future__ import absolute_import
 
 import re
 
@@ -33,7 +32,7 @@ class LangComment(Comment):
 
 class LangEntity(LiteralEntity):
     def __init__(self, source_string, translation_string, all, tags):
-        super(LangEntity, self).__init__(
+        super().__init__(
             key=source_string,  # .lang files use the source as the key.
             val=translation_string,
             all=all,
@@ -135,7 +134,7 @@ def node_text(node):
     actually be a list of nodes due to repetition.
     """
     if node is None:
-        return u''
+        return ''
     elif isinstance(node, list):
         return ''.join([n.text for n in node])
     else:

--- a/contrib/lang/tests/test_parser.py
+++ b/contrib/lang/tests/test_parser.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import unittest
 from compare_locales import parser
 from parsimonious.exceptions import ParseError

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from setuptools import setup, find_packages
 
 import sys

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,7 @@ Intended Audience :: Developers
 License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
 Operating System :: OS Independent
 Programming Language :: Python
-Programming Language :: Python :: 2
-Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.5
-Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
@@ -41,7 +37,7 @@ setup(name="compare-locales",
       license="MPL 2.0",
       classifiers=CLASSIFIERS.split("\n"),
       platforms=["any"],
-      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4',
+      python_requires='>=3.7, <4',
       entry_points={
         'console_scripts':
         [

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(name="compare-locales",
       install_requires=[
           'fluent.syntax >=0.18.0, <0.19',
           'pytoml',
-          'six',
       ],
       tests_require=[
           'mock<4.0',

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,9 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, py39, flake8, lang, integration
+envlist = py37, py38, py39, flake8, lang, integration
 skipsdist=True
 
 [gh-actions]
 python =
-  2.7: py27
-  3.5: py35
-  3.6: py36
   3.7: py37
   3.8: py38
   3.9: py39, lang, flake8, integration


### PR DESCRIPTION
This will require the next release to be a semver-major bump.

Code style was updated using `pyupgrade`.