### PR TITLE
switch from `pytoml` to `toml`

### DIFF
--- a/compare_locales/paths/configparser.py
+++ b/compare_locales/paths/configparser.py
@@ -7,7 +7,7 @@ import logging
 from compare_locales import mozpath
 from .project import ProjectConfig
 from .matcher import expand
-import pytoml as toml
+import toml
 
 
 class ConfigNotFound(EnvironmentError):
@@ -53,7 +53,7 @@ class TOMLParser:
         try:
             with open(ctx.path, 'rb') as fin:
                 ctx.data = toml.load(fin)
-        except (toml.TomlError, OSError):
+        except (toml.TomlDecodeError, OSError):
             raise ConfigNotFound(ctx.path)
 
     def processBasePath(self, ctx):

--- a/compare_locales/tests/paths/__init__.py
+++ b/compare_locales/tests/paths/__init__.py
@@ -8,7 +8,7 @@ from compare_locales.paths import (
     ProjectConfig, File, ProjectFiles, TOMLParser
 )
 from compare_locales import mozpath
-import pytoml as toml
+import toml
 
 
 class Rooted:

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ setup(name="compare-locales",
       },
       install_requires=[
           'fluent.syntax >=0.18.0, <0.19',
-          'pytoml',
+          'six',  # undeclared dependency of fluent-syntax 0.18.1
+          'toml',
       ],
       tests_require=[
           'mock<4.0',

--- a/tox.ini
+++ b/tox.ini
@@ -24,5 +24,6 @@ commands=python -m unittest discover -s compare_locales/integration_tests
 [testenv:lang]
 basepython=python3.9
 deps=
+  --editable=.
   --editable=contrib/lang
 commands=python -m unittest discover contrib/lang/tests


### PR DESCRIPTION
mozilla-central is switching from use of `pytoml` to `toml` (see bugzilla bug 1804178). Follow suit.