### PR TITLE
Bug 1796705 - l10n.toml doesn't process multiple entries if they are same directory with wild card

### DIFF
--- a/compare_locales/paths/files.py
+++ b/compare_locales/paths/files.py
@@ -92,6 +92,10 @@ class ProjectFiles:
                         mozpath.realpath(m_['l10n'].prefix)):
                     # ok, not the same thing, continue
                     continue
+                if m['l10n'].pattern != m_['l10n'].pattern:
+                    # We cannot guess whether same entry until the pattern is
+                    # resolved, continue
+                    continue
                 # check that we're comparing the same thing
                 if 'reference' in m:
                     if (mozpath.realpath(m['reference'].prefix) !=

--- a/compare_locales/tests/paths/test_files.py
+++ b/compare_locales/tests/paths/test_files.py
@@ -557,7 +557,7 @@ locales = [
     reference = "reference/*bar.ftl"
     l10n = "{l}*bar.ftl"
 ''',
-})
+            })
         cfg = parser.parse(
             self.path('/base.toml'),
             env={'l10n_base': self.path('/l10n')}

--- a/compare_locales/tests/paths/test_files.py
+++ b/compare_locales/tests/paths/test_files.py
@@ -539,7 +539,25 @@ locales = [
 [[paths]]
     reference = "reference/*"
     l10n = "{l}*"
-'''})
+''',
+            "wildcard.toml":
+            '''\
+basepath = "."
+
+locales = [
+    "de",
+]
+[env]
+    l = "{l10n_base}/{locale}/"
+
+[[paths]]
+    reference = "reference/*foo.ftl"
+    l10n = "{l}*foo.ftl"
+[[paths]]
+    reference = "reference/*bar.ftl"
+    l10n = "{l}*bar.ftl"
+''',
+})
         cfg = parser.parse(
             self.path('/base.toml'),
             env={'l10n_base': self.path('/l10n')}
@@ -566,5 +584,30 @@ locales = [
                 (self.path('/l10n/de/ref.ftl'),
                  self.path('/reference/ref.ftl'),
                  self.path('/mergers/de/ref.ftl'),
+                 set()),
+            ])
+
+        cfg = parser.parse(
+            self.path('/wildcard.toml'),
+            env={'l10n_base': self.path('/l10n')}
+        )
+        mocks = [
+            self.path(leaf)
+            for leaf in [
+                '/l10n/de/foofoo.ftl',
+                '/l10n/de/barbar.ftl',
+            ]
+        ]
+        files = MockProjectFiles(mocks, 'de', [cfg], self.path('/mergers'))
+        self.assertListEqual(
+            list(files),
+            [
+                (self.path('/l10n/de/barbar.ftl'),
+                 self.path('/reference/barbar.ftl'),
+                 self.path('/mergers/de/barbar.ftl'),
+                 set()),
+                (self.path('/l10n/de/foofoo.ftl'),
+                 self.path('/reference/foofoo.ftl'),
+                 self.path('/mergers/de/foofoo.ftl'),
                  set()),
             ])


### PR DESCRIPTION
It is used in https://searchfox.org/mozilla-central/source/mobile/android/locales/l10n.toml. But this toml file doesn't work well.

```
[[paths]]
    reference = "toolkit/locales/en-US/toolkit/about/*Support.ftl"
    l10n = "{l}toolkit/toolkit/about/*Support.ftl"

[[paths]]
    reference = "toolkit/locales/en-US/toolkit/about/*Webrtc.ftl"
    l10n = "{l}toolkit/toolkit/about/*Webrtc.ftl"
```

This toml file only copies last entry that has wild card, not all. `*Support.ftl` isn't handled.  `ProjectFiles.__init__` tries to remove duplicated entries, but this doesn't consider that entry has wild card.