### PR TITLE
Note support for fluent.syntax 0.19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
+.*
 *.orig
 *.pyc
 build/
 dist/
 compare_locales.egg-info/
-.eggs/
-.tox/
-.coverage
 htmlcov/

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(name="compare-locales",
           'compare_locales.tests': ['data/*.properties', 'data/*.dtd']
       },
       install_requires=[
-          'fluent.syntax >=0.18.0, <0.19',
+          'fluent.syntax >=0.18.0, <0.20',
           'six',  # undeclared dependency of fluent-syntax 0.18.1
           'toml',
       ],


### PR DESCRIPTION
Now that `fluent.syntax` 0.19.0 has been released, we should note that it's fine to use with `compare-locales`.

Also, clean up the `.gitignore` a bit.