### PR TITLE
fix: Open file as text for toml.load()

### DIFF
--- a/compare_locales/paths/configparser.py
+++ b/compare_locales/paths/configparser.py
@@ -51,7 +51,7 @@ class TOMLParser:
 
     def load(self, ctx):
         try:
-            with open(ctx.path, 'rb') as fin:
+            with open(ctx.path, 'rt') as fin:
                 ctx.data = toml.load(fin)
         except (toml.TomlDecodeError, OSError):
             raise ConfigNotFound(ctx.path)

--- a/compare_locales/tests/paths/test_configparser.py
+++ b/compare_locales/tests/paths/test_configparser.py
@@ -2,9 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import tempfile
 import unittest
 
 from . import MockTOMLParser
+from compare_locales.paths import TOMLParser
 from compare_locales.paths.matcher import Matcher
 from compare_locales.paths.project import ProjectConfig, ExcludeError
 from compare_locales import mozpath
@@ -121,3 +123,9 @@ basepath = "."
         self.assertNotIn("reference", paths[0])
         self.assertIn("test", paths[0])
         self.assertListEqual(paths[0]["test"], ["run_this"])
+
+    def test_toml_load(self):
+        with tempfile.NamedTemporaryFile(suffix=".toml") as file:
+            file.write(b'basepath = "."\n')
+            config = TOMLParser().parse(file.name)
+            self.assertIsInstance(config, ProjectConfig)

--- a/compare_locales/tests/paths/test_configparser.py
+++ b/compare_locales/tests/paths/test_configparser.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import os
 import tempfile
 import unittest
 
@@ -125,7 +126,11 @@ basepath = "."
         self.assertListEqual(paths[0]["test"], ["run_this"])
 
     def test_toml_load(self):
-        with tempfile.NamedTemporaryFile(suffix=".toml") as file:
-            file.write(b'basepath = "."\n')
-            config = TOMLParser().parse(file.name)
+        fd, path = tempfile.mkstemp(suffix=".toml")
+        try:
+            os.write(fd, b'basepath = "."\n')
+            os.close(fd)
+            config = TOMLParser().parse(path)
             self.assertIsInstance(config, ProjectConfig)
+        finally:
+            os.remove(path)


### PR DESCRIPTION
Fixes #12
CC @stevejalim

It looks like the parser's `load()` method was not previously tested, on account of being masked by the mock implementation.