### PR TITLE
Add MF2-ish message/resource representations

### DIFF
--- a/compare_locales/resource/__init__.py
+++ b/compare_locales/resource/__init__.py
@@ -1,0 +1,43 @@
+from .elements import (
+    CatchallKey,
+    Expression,
+    FunctionRef,
+    Literal,
+    OptionValue,
+    Pattern,
+    Text,
+    VariableRef,
+    VariantKey,
+    Declarations,
+    Message,
+    Comment,
+    Junk,
+    Entry,
+    Span,
+    PatternMessage,
+    SelectMessage,
+)
+from .from_fluent import resourceFromFluent
+from .from_properties import resourceFromProperties
+
+__all__ = [
+    "CatchallKey",
+    "Comment",
+    "Declarations",
+    "Entry",
+    "Expression",
+    "FunctionRef",
+    "Junk",
+    "Literal",
+    "Message",
+    "OptionValue",
+    "Pattern",
+    "PatternMessage",
+    "SelectMessage",
+    "Span",
+    "Text",
+    "VariableRef",
+    "VariantKey",
+    "resourceFromFluent",
+    "resourceFromProperties",
+]

--- a/compare_locales/resource/elements.py
+++ b/compare_locales/resource/elements.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+from typing import List, Optional, OrderedDict, Tuple, Union
+
+
+# PATTERN
+
+
+@dataclass
+class CatchallKey:
+    "The catch-all variant key matches all values."
+
+    value: Optional[str] = None
+
+
+@dataclass
+class FunctionRef:
+    """
+    To resolve a FunctionRef, an externally defined function is called.
+
+    The `name` identifies a function that takes in the arguments `args`, the
+    current locale, as well as any `options`, and returns some corresponding
+    output. Likely functions available by default would include `'plural'` for
+    determining the plural category of a numeric value, as well as `'number'`
+    and `'date'` for formatting values.
+    """
+
+    name: str
+    operand: Union[Literal, VariableRef, None] = None
+    options: OrderedDict[str, Union[Literal, VariableRef]] = OrderedDict()
+
+
+@dataclass
+class Literal:
+    """An immediately defined value.
+
+    Always contains a string value. In Function arguments and options,
+    the expected type of the value may result in the value being
+    further parsed as a boolean or a number.
+    """
+
+    quoted: bool
+    value: str
+
+
+@dataclass
+class Text:
+    "Top-level literal content."
+
+    value: str
+
+
+@dataclass
+class VariableRef:
+    """
+    The value of a VariableRef is defined by the current Scope.
+
+    To refer to an inner property of an object value, use `.` as a separator
+    in case of conflict, the longest starting substring wins.
+    For example, `'user.name'` would be first matched by an exactly matching top-level key,
+    and in case that fails, with the `'name'` property of the `'user'` object:
+    The runtime scopes `{ 'user.name': 'Kat' }` and `{ user: { name: 'Kat' } }`
+    would both resolve a `'user.name'` VariableRef as the string `'Kat'`.
+    """
+
+    name: str
+
+
+Expression = Union[FunctionRef, Literal, VariableRef]
+
+OptionValue = Union[Literal, VariableRef]
+
+Pattern = List[Union[Expression, Text]]
+"""
+The body of each message is composed of a sequence of parts, some of them fixed (Text),
+others placeholders for values depending on additional data.
+"""
+
+VariantKey = Union[Literal, CatchallKey]
+
+
+# MESSAGE
+
+
+@dataclass
+class PatternMessage:
+    """
+    A single message with no variants.
+    """
+
+    pattern: Pattern
+    declarations: Declarations = OrderedDict()
+
+
+@dataclass
+class SelectMessage:
+    """
+    SelectMessage generalises the plural, selectordinal and select
+    argument types of MessageFormat 1.
+    Each case is defined by a key of one or more string identifiers,
+    and selection between them is made according to
+    the values of a corresponding number of placeholders.
+    The result of the selection is always a single Pattern.
+    """
+
+    selectors: List[Expression]
+    variants: List[Tuple[List[VariantKey], Pattern]]
+    declarations: Declarations = OrderedDict()
+
+
+Declarations = OrderedDict[str, Expression]
+"""
+A message may declare any number of local variables or aliases,
+each with a value defined by an expression.
+Earlier declarations may not refer to values that are defined later.
+"""
+
+
+# RESOURCE
+
+
+@dataclass
+class Message:
+    """
+    The representation of a single message.
+    Depending on the source format, `key` may include more than one part.
+    For example, Fluent attributes use a `(str, str)` key.
+    The shape of the `value` is an implementation detail,
+    and may vary for the same message in different languages.
+    """
+
+    key: Tuple[str, ...]
+    value: Union[PatternMessage, SelectMessage]
+    span: Span
+    comment: Optional[Span] = None
+
+
+@dataclass
+class Comment:
+    "Standalone comment"
+    span: Span
+
+
+@dataclass
+class Junk:
+    "Invalid content"
+    span: Span
+
+
+Span = Tuple[int, int]
+"The 0-indexed `[start, end)` character range of a resource item."
+
+Entry = Union[Comment, Message, Junk]

--- a/compare_locales/resource/elements.py
+++ b/compare_locales/resource/elements.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-
-
+from dataclasses import dataclass, field
 from typing import List, Optional, OrderedDict, Tuple, Union
 
 
@@ -30,7 +28,9 @@ class FunctionRef:
 
     name: str
     operand: Union[Literal, VariableRef, None] = None
-    options: OrderedDict[str, Union[Literal, VariableRef]] = OrderedDict()
+    options: OrderedDict[str, Union[Literal, VariableRef]] = field(
+        default_factory=OrderedDict
+    )
 
 
 @dataclass
@@ -92,7 +92,7 @@ class PatternMessage:
     """
 
     pattern: Pattern
-    declarations: Declarations = OrderedDict()
+    declarations: Declarations = field(default_factory=OrderedDict)
 
 
 @dataclass
@@ -108,7 +108,7 @@ class SelectMessage:
 
     selectors: List[Expression]
     variants: List[Tuple[List[VariantKey], Pattern]]
-    declarations: Declarations = OrderedDict()
+    declarations: Declarations = field(default_factory=OrderedDict)
 
 
 Declarations = OrderedDict[str, Expression]

--- a/compare_locales/resource/from_fluent.py
+++ b/compare_locales/resource/from_fluent.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import Iterator, List, Optional, Tuple, Union
+
+from fluent.syntax import ast as Fluent
+
+from .elements import (
+    CatchallKey,
+    Comment,
+    Entry,
+    Expression,
+    FunctionRef,
+    Junk,
+    Literal,
+    Message,
+    OptionValue,
+    Pattern,
+    PatternMessage,
+    SelectMessage,
+    Text,
+    VariableRef,
+    VariantKey,
+)
+
+
+class SelectArg:
+    def __init__(self, sel: Fluent.SelectExpression) -> None:
+        self.defaultName = ""
+        self.selector = sel.selector
+
+        def getName(v: Fluent.Variant) -> Union[str, None]:
+            name = v.key.name if isinstance(v.key, Fluent.Identifier) else v.key.value
+            if v.default:
+                self.defaultName = str(name)
+                return None
+            else:
+                return name
+
+        self.keys: List[Union[str, int, None]] = list(map(getName, sel.variants))
+
+
+def findSelectArgs(pattern: Fluent.Pattern) -> List[SelectArg]:
+    args: List[SelectArg] = []
+
+    def add(arg: SelectArg) -> None:
+        prev = next((a for a in args if a.selector.equals(arg.selector)), None)
+        if prev:
+            prev.keys += arg.keys
+        else:
+            args.append(arg)
+
+    for el in pattern.elements:
+        if isinstance(el, Fluent.Placeable) and isinstance(
+            el.expression, Fluent.SelectExpression
+        ):
+            add(SelectArg(el.expression))
+            for v in el.expression.variants:
+                for arg in findSelectArgs(v.value):
+                    add(arg)
+    return args
+
+
+def getOptions(args: Optional[Fluent.CallArguments]) -> OrderedDict[str, OptionValue]:
+    options: OrderedDict[str, OptionValue] = OrderedDict()
+    if args:
+        for arg in args.named:
+            options[arg.name.name] = (
+                Literal(False, arg.value.value)
+                if isinstance(arg.value, Fluent.NumberLiteral)
+                else Literal(True, arg.value.parse()["value"])
+            )
+    return options
+
+
+def expressionToPart(exp: Union[Fluent.Expression, Fluent.Placeable]) -> Expression:
+    if isinstance(exp, Fluent.NumberLiteral):
+        return FunctionRef("NUMBER", Literal(False, exp.value))
+    elif isinstance(exp, Fluent.StringLiteral):
+        return Literal(True, exp.parse()["value"])
+    elif isinstance(exp, Fluent.VariableReference):
+        return VariableRef(exp.id.name)
+    elif isinstance(exp, Fluent.FunctionReference):
+        args = [expressionToPart(exp) for exp in exp.arguments.positional]
+        if len(args) > 1:
+            raise Exception("More than one positional argument is not supported.")
+        operand = args[0]
+        if isinstance(operand, FunctionRef):
+            raise Exception("A Fluent function is not supported here.")
+        options = getOptions(exp.arguments)
+        return FunctionRef(exp.id.name, operand, options)
+    elif isinstance(exp, Fluent.MessageReference):
+        msgId = (
+            f"${exp.id.name}.${exp.attribute.name}" if exp.attribute else exp.id.name
+        )
+        return FunctionRef("MESSAGE", Literal(False, msgId))
+    elif isinstance(exp, Fluent.TermReference):
+        msgId = (
+            "-${exp.id.name}.${exp.attribute.name}"
+            if exp.attribute
+            else f"-${exp.id.name}"
+        )
+        operand = Literal(False, msgId)
+        options = getOptions(exp.arguments)
+        return FunctionRef("MESSAGE", operand, options)
+    elif isinstance(exp, Fluent.Placeable):
+        return expressionToPart(exp.expression)
+    raise Exception(f"${exp.__class__.__name__} not supported here")
+
+
+def elementToPart(el: Union[Fluent.TextElement, Fluent.Placeable]) -> Expression | Text:
+    if isinstance(el, Fluent.TextElement):
+        return Text(el.value)
+    else:
+        return expressionToPart(el.expression)
+
+
+def asFluentSelect(
+    el: Union[Fluent.TextElement, Fluent.Placeable]
+) -> Optional[Fluent.SelectExpression]:
+    if isinstance(el, Fluent.TextElement):
+        return None
+    elif isinstance(el.expression, Fluent.SelectExpression):
+        return el.expression
+    elif isinstance(el.expression, Fluent.Placeable):
+        return asFluentSelect(el.expression)
+    else:
+        return None
+
+
+def messageFromFluentPattern(
+    ast: Fluent.Pattern,
+) -> Union[PatternMessage, SelectMessage]:
+    """
+    Compile a Fluent.Pattern (i.e. the value of a Fluent message or an attribute)
+    into a Message data object.
+    """
+    args = findSelectArgs(ast)
+    if len(args) == 0:
+        return PatternMessage([elementToPart(el) for el in ast.elements])
+
+    # First determine the keys for all cases, with empty values
+    keys: List[List[Union[str, int, None]]]
+    for i, arg in enumerate(args):
+        kk: List[Union[str, int, None]] = []
+        for key in arg.keys:
+            if key not in kk:
+                kk.append(key)
+        kk.sort(key=lambda key: 1 if key is None else -1 if isinstance(key, int) else 0)
+        if i == 0:
+            keys = [[key] for key in kk]
+        else:
+            for i in range(len(keys), 0, -1):
+                prev = keys[i - 1]
+                keys[i - 1 : i] = [prev + [key] for key in kk]
+
+    variants: List[Tuple[List[VariantKey], Pattern]] = [
+        (
+            [
+                CatchallKey(args[i].defaultName)
+                if k is None
+                else Literal(False, str(k))
+                for i, k in enumerate(key)
+            ],
+            [],
+        )
+        for key in keys
+    ]
+
+    def addParts(
+        pattern: Fluent.Pattern,
+        filter: List[Tuple[int, Optional[str]]],  # [(idx, value)]
+    ):
+        """
+        This reads `args` and modifies `variants`
+
+        @param filter - Selects which cases we're adding to
+        """
+        for el in pattern.elements:
+            sel = asFluentSelect(el)
+            if sel:
+                idx = next(
+                    (i for (i, a) in enumerate(args) if a.selector.equals(sel.selector))
+                )
+                for v in sel.variants:
+                    value = (
+                        None
+                        if v.default
+                        else v.key.name
+                        if isinstance(v.key, Fluent.Identifier)
+                        else v.key.value
+                    )
+                    addParts(v.value, filter + [(idx, value)])
+            else:
+                for vk, vp in variants:
+                    if all(
+                        value is None
+                        if isinstance(key, CatchallKey)
+                        else value == key.value
+                        for key, value in map(lambda f: (vk[f[0]], f[1]), filter)
+                    ):
+                        last = vp[-1]
+                        part = elementToPart(el)
+                        if isinstance(last, Text) and isinstance(part, Text):
+                            last.value += part.value
+                        else:
+                            vp.append(part)
+
+    addParts(ast, [])
+
+    return SelectMessage([expressionToPart(arg.selector) for arg in args], variants)
+
+
+def entriesFromFluent(fe: Fluent.EntryType) -> Iterator[Entry]:
+    if not fe.span:
+        raise Exception("Fluent parser must include spans in output")
+    if isinstance(fe, Fluent.Message):
+        id = fe.id.name
+        cspan = fe.comment.span if fe.comment else None
+        comment = (cspan.start, cspan.end) if cspan else None
+        if fe.value:
+            value = messageFromFluentPattern(fe.value)
+            ispan = fe.id.span or fe.span
+            vspan = fe.value.span or fe.span
+            yield Message((id,), value, (ispan.start, vspan.end), comment)
+            if comment:
+                comment = None
+        for attr in fe.attributes:
+            value = messageFromFluentPattern(attr.value)
+            span = attr.span or fe.span
+            yield Message((id, attr.id.name), value, (span.start, span.end), comment)
+            if comment:
+                comment = None
+    elif isinstance(fe, Fluent.Term):
+        id = "-" + fe.id.name
+        value = messageFromFluentPattern(fe.value)
+        ispan = fe.id.span or fe.span
+        vspan = fe.value.span or fe.span
+        cspan = fe.comment.span if fe.comment else None
+        comment = (cspan.start, cspan.end) if cspan else None
+        yield Message((id,), value, (ispan.start, vspan.end), comment)
+        for attr in fe.attributes:
+            value = messageFromFluentPattern(attr.value)
+            span = attr.span or span
+            yield Message((id, attr.id.name), value, (span.start, span.end))
+    else:
+        span_ = (fe.span.start, fe.span.end)
+        yield Comment(span_) if isinstance(fe, Fluent.BaseComment) else Junk(span_)
+
+
+def resourceFromFluent(ast: Fluent.Resource) -> List[Entry]:
+    """
+    Compile a Fluent resource into a message resource.
+    """
+    return [entry for fe in ast.body for entry in entriesFromFluent(fe)]

--- a/compare_locales/resource/from_fluent.py
+++ b/compare_locales/resource/from_fluent.py
@@ -139,7 +139,11 @@ def messageFromFluentPattern(
     if len(args) == 0:
         return PatternMessage([elementToPart(el) for el in ast.elements])
 
-    # First determine the keys for all cases, with empty values
+    # First determine the keys for all variants, with empty values.
+    # Fluent supports selectors within a message,
+    # while our data model supports top-level selectors only.
+    # Mapping between these approaches gets a bit complicated
+    # when a message contains more than one selector.
     keys: List[List[Union[str, int, None]]]
     for i, arg in enumerate(args):
         kk: List[Union[str, int, None]] = []
@@ -150,9 +154,12 @@ def messageFromFluentPattern(
         if i == 0:
             keys = [[key] for key in kk]
         else:
-            for i in range(len(keys), 0, -1):
-                prev = keys[i - 1]
-                keys[i - 1 : i] = [prev + [key] for key in kk]
+            # For selectors after the first,
+            # replace each previous variant with len(kk) variants,
+            # one for each of this selector's keys.
+            for j in range(len(keys), 0, -1):
+                prev = keys[j - 1]
+                keys[j - 1 : j] = [prev + [key] for key in kk]
 
     variants: List[Tuple[List[VariantKey], Pattern]] = [
         (

--- a/compare_locales/resource/from_fluent.py
+++ b/compare_locales/resource/from_fluent.py
@@ -206,7 +206,7 @@ def messageFromFluentPattern(
                         else value == key.value
                         for key, value in map(lambda f: (vk[f[0]], f[1]), filter)
                     ):
-                        last = vp[-1]
+                        last = vp[-1] if len(vp) else None
                         part = elementToPart(el)
                         if isinstance(last, Text) and isinstance(part, Text):
                             last.value += part.value

--- a/compare_locales/resource/from_properties.py
+++ b/compare_locales/resource/from_properties.py
@@ -30,18 +30,16 @@ def patternFromPropertiesValue(
     """
 
     pattern: Pattern = []
-    prevEnd = 0
+    prev_end = 0
     if variables:
         for match in variables.finditer(value):
             start = match.start()
-            if start > prevEnd:
-                pattern.append(Text(value[prevEnd:start]))
+            if start > prev_end:
+                pattern.append(Text(value[prev_end:start]))
             pattern.append(VariableRef(match[0]))
-            prevEnd = match.end()
-    if len(pattern) == 0:
-        pattern.append(Text(value))
-    elif prevEnd < len(value):
-        pattern.append(Text(value[prevEnd:]))
+            prev_end = match.end()
+    if len(pattern) == 0 or prev_end < len(value):
+        pattern.append(Text(value[prev_end:]))
     return PatternMessage(pattern)
 
 

--- a/compare_locales/resource/from_properties.py
+++ b/compare_locales/resource/from_properties.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import re
+from typing import Iterable, List, Optional, Union
+
+from ..parsers import Comment as ParserComment
+from ..parsers import Entity as ParserEntity
+from ..parsers import Junk as ParserJunk
+from ..parsers import Whitespace as ParserWhitespace
+from .elements import (
+    Comment,
+    Entry,
+    Junk,
+    Message,
+    Pattern,
+    PatternMessage,
+    Text,
+    VariableRef,
+)
+
+
+def patternFromPropertiesValue(
+    value: str, variables: Optional[re.Pattern[str]] = None
+) -> PatternMessage:
+    """
+    Compile a .properties value into a PatternMessage data class.
+
+    `variables` may be a compiled regexp identifying a variable placeholder from the value.
+    Its captured groups (if any) are ignored.
+    """
+
+    pattern: Pattern = []
+    prevEnd = 0
+    if variables:
+        for match in variables.finditer(value):
+            start = match.start()
+            if start > prevEnd:
+                pattern.append(Text(value[prevEnd:start]))
+            pattern.append(VariableRef(match[0]))
+            prevEnd = match.end()
+    if len(pattern) == 0:
+        pattern.append(Text(value))
+    elif prevEnd < len(value):
+        pattern.append(Text(value[prevEnd:]))
+    return PatternMessage(pattern)
+
+
+def resourceFromProperties(
+    entries: Iterable[Union[ParserComment, ParserWhitespace, ParserEntity, ParserJunk]],
+    variables: Optional[re.Pattern[str]] = None,
+) -> List[Entry]:
+    """
+    Compile a parsed .properties file into a message resource.
+
+    `variables` may be a compiled regexp identifying a variable placeholder.
+    """
+
+    res: List[Entry] = []
+    for pe in entries:
+        if isinstance(pe, ParserEntity):
+            value = patternFromPropertiesValue(pe.val, variables)
+            cspan = pe.pre_comment.span if pe.pre_comment else None
+            res.append(Message((pe.key,), value, pe.span, cspan))
+        elif isinstance(pe, ParserComment):
+            res.append(Comment(pe.span))
+        elif not isinstance(pe, ParserWhitespace):
+            res.append(Junk(pe.span))
+    return res

--- a/compare_locales/resource/tests/test_fluent.py
+++ b/compare_locales/resource/tests/test_fluent.py
@@ -1,0 +1,176 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import unittest
+
+from fluent.syntax import FluentParser
+
+from .. import (
+    Comment,
+    FunctionRef,
+    Junk,
+    Literal,
+    Message,
+    PatternMessage,
+    Text,
+    VariableRef,
+    resourceFromFluent,
+)
+
+
+class TestFluentParser(unittest.TestCase):
+    def test_simple_message(self):
+        src = "a = A"
+        ast = FluentParser().parse(src)
+        res = resourceFromFluent(ast)
+        self.assertEqual(
+            res,
+            [Message(("a",), PatternMessage([Text("A")]), (0, 5))],
+        )
+
+    def test_complex_message(self):
+        src = "abc = A { $arg } B { msg } C"
+        ast = FluentParser().parse(src)
+        res = resourceFromFluent(ast)
+        self.assertEqual(
+            res,
+            [
+                Message(
+                    ("abc",),
+                    PatternMessage(
+                        [
+                            Text("A "),
+                            VariableRef("arg"),
+                            Text(" B "),
+                            FunctionRef("MESSAGE", Literal(False, "msg")),
+                            Text(" C"),
+                        ]
+                    ),
+                    res[0].span,
+                )
+            ],
+        )
+
+    def test_multiline_message(self):
+        src = """\
+abc =
+    A
+    B
+    C
+"""
+        ast = FluentParser().parse(src)
+        res = resourceFromFluent(ast)
+        self.assertEqual(
+            res,
+            [Message(("abc",), PatternMessage([Text("A\nB\nC")]), res[0].span)],
+        )
+
+    def test_message_with_attribute(self):
+        src = """\
+
+
+abc = ABC
+    .attr = Attr
+"""
+        ast = FluentParser().parse(src)
+        res = resourceFromFluent(ast)
+        self.assertEqual(
+            res,
+            [
+                Message(("abc",), PatternMessage([Text("ABC")]), (2, 11)),
+                Message(("abc", "attr"), PatternMessage([Text("Attr")]), (16, 28)),
+            ],
+        )
+
+    def test_message_with_attribute_and_no_value(self):
+        src = """\
+abc =
+    .attr = Attr
+"""
+        ast = FluentParser().parse(src)
+        res = resourceFromFluent(ast)
+        self.assertEqual(
+            res,
+            [
+                Message(("abc", "attr"), PatternMessage([Text("Attr")]), (10, 22)),
+            ],
+        )
+
+    def test_non_localizable(self):
+        src = """\
+### Resource Comment
+
+foo = Foo
+
+## Group Comment
+
+-bar = Bar
+
+##
+
+# Standalone Comment
+
+# Baz Comment
+baz = Baz
+"""
+        ast = FluentParser().parse(src)
+        res = resourceFromFluent(ast)
+        self.assertEqual(
+            res,
+            [
+                Comment(res[0].span),
+                Message(("foo",), PatternMessage([Text("Foo")]), res[1].span),
+                Comment(res[2].span),
+                Message(("-bar",), PatternMessage([Text("Bar")]), res[3].span),
+                Comment(res[4].span),
+                Comment(res[5].span),
+                Message(
+                    ("baz",),
+                    PatternMessage([Text("Baz")]),
+                    res[6].span,
+                    comment=res[6].comment,
+                ),
+            ],
+        )
+        c = res[0].span
+        self.assertEqual(src[c[0] : c[1]], "### Resource Comment")
+        c = res[2].span
+        self.assertEqual(src[c[0] : c[1]], "## Group Comment")
+        c = res[4].span
+        self.assertEqual(src[c[0] : c[1]], "##")
+        c = res[5].span
+        self.assertEqual(src[c[0] : c[1]], "# Standalone Comment")
+        c = res[6].comment
+        self.assertEqual(src[c[0] : c[1]], "# Baz Comment")
+
+    def test_junk(self):
+        src = """\
+# Comment
+
+Line of junk
+
+# Comment
+msg = value
+"""
+        ast = FluentParser().parse(src)
+        res = resourceFromFluent(ast)
+        self.assertEqual(
+            res,
+            [
+                Comment(res[0].span),
+                Junk(res[1].span),
+                Message(
+                    ("msg",),
+                    PatternMessage([Text("value")]),
+                    res[2].span,
+                    comment=res[2].comment,
+                ),
+            ],
+        )
+        c = res[0].span
+        self.assertEqual(src[c[0] : c[1]], "# Comment")
+        c = res[1].span
+        self.assertEqual(src[c[0] : c[1]], "Line of junk\n\n")
+        c = res[2].comment
+        self.assertEqual(src[c[0] : c[1]], "# Comment")

--- a/compare_locales/resource/tests/test_properties.py
+++ b/compare_locales/resource/tests/test_properties.py
@@ -1,0 +1,174 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import unittest
+
+from ...parsers import PropertiesParser
+from .. import Comment, Junk, Message, PatternMessage, Text, resourceFromProperties
+
+
+class TestPropertiesResource(unittest.TestCase):
+    def test_backslashes(self):
+        src = r"""one_line = This is one line
+two_line = This is the first \
+of two lines
+one_line_trailing = This line ends in \\
+and has junk
+two_lines_triple = This line is one of two and ends in \\\
+and still has another line coming
+"""
+        parser = PropertiesParser()
+        parser.readUnicode(src)
+        res = resourceFromProperties(parser.walk())
+        self.assertEqual(
+            res,
+            [
+                Message(
+                    ("one_line",), PatternMessage([Text("This is one line")]), (0, 27)
+                ),
+                Message(
+                    ("two_line",),
+                    PatternMessage([Text("This is the first of two lines")]),
+                    (28, 71),
+                ),
+                Message(
+                    ("one_line_trailing",),
+                    PatternMessage([Text("This line ends in \\")]),
+                    (72, 112),
+                ),
+                Junk((113, 126)),
+                Message(
+                    ("two_lines_triple",),
+                    PatternMessage(
+                        [
+                            Text(
+                                "This line is one of two and ends in \\and still has another line coming"
+                            )
+                        ]
+                    ),
+                    (126, 218),
+                ),
+            ],
+        )
+
+    def test_license_header(self):
+        src = """\
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+foo=value
+"""
+        parser = PropertiesParser()
+        parser.readUnicode(src)
+        res = resourceFromProperties(parser.walk())
+        self.assertEqual(
+            res,
+            [
+                Comment((0, 198)),
+                Message(("foo",), PatternMessage([Text("value")]), (200, 209)),
+            ],
+        )
+
+    def test_escapes(self):
+        src = rb"""
+# unicode escapes
+zero = some \unicode
+one = \u0
+two = \u41
+three = \u042
+four = \u0043
+five = \u0044a
+six = \a
+seven = \n\r\t\\
+"""
+        parser = PropertiesParser()
+        parser.readContents(src)
+        res = resourceFromProperties(parser.walk())
+        self.assertEqual(
+            res,
+            [
+                Message(
+                    ("zero",),
+                    PatternMessage([Text("some unicode")]),
+                    span=(19, 39),
+                    comment=(1, 18),
+                ),
+                Message(("one",), PatternMessage([Text(chr(0))]), res[1].span),
+                Message(("two",), PatternMessage([Text("A")]), res[2].span),
+                Message(("three",), PatternMessage([Text("B")]), res[3].span),
+                Message(("four",), PatternMessage([Text("C")]), res[4].span),
+                Message(("five",), PatternMessage([Text("Da")]), res[5].span),
+                Message(("six",), PatternMessage([Text("a")]), res[6].span),
+                Message(("seven",), PatternMessage([Text("\n\r\t\\")]), res[7].span),
+            ],
+        )
+        start, end = res[0].comment
+        self.assertEqual(src[start:end], b"# unicode escapes")
+
+    def test_trailing_comment(self):
+        src = """first = string
+second = string
+
+#
+#commented out
+"""
+        parser = PropertiesParser()
+        parser.readUnicode(src)
+        res = resourceFromProperties(parser.walk())
+        self.assertEqual(
+            res,
+            [
+                Message(("first",), PatternMessage([Text("string")]), res[0].span),
+                Message(("second",), PatternMessage([Text("string")]), res[1].span),
+                Comment(res[2].span),
+            ],
+        )
+        start, end = res[2].span
+        self.assertEqual(src[start:end], "#\n#commented out")
+
+    def test_empty(self):
+        parser = PropertiesParser()
+        for src in ["", "\n", "\n\n", " \n\n"]:
+            parser.readUnicode(src)
+            res = resourceFromProperties(parser.walk())
+            self.assertEqual(res, [])
+
+    def test_pre_comment(self):
+        src = """\
+# comment
+one = string
+
+# standalone
+
+# glued
+second = string
+"""
+        parser = PropertiesParser()
+        parser.readUnicode(src)
+        res = resourceFromProperties(parser.walk())
+        self.assertEqual(
+            res,
+            [
+                Message(
+                    ("one",),
+                    PatternMessage([Text("string")]),
+                    span=(10, 22),
+                    comment=(0, 9),
+                ),
+                Comment(res[1].span),
+                Message(
+                    ("second",),
+                    PatternMessage([Text("string")]),
+                    res[2].span,
+                    comment=res[2].comment,
+                ),
+            ],
+        )
+        c0 = res[0].comment
+        self.assertEqual(src[c0[0] : c0[1]], "# comment")
+        c1 = res[1].span
+        self.assertEqual(src[c1[0] : c1[1]], "# standalone")
+        c2 = res[2].comment
+        self.assertEqual(src[c2[0] : c2[1]], "# glued")

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
   pytest
   toml
 commands =
-  python -m pytest --pyargs compare_locales/tests compare_locales/parsers/tests
+  python -m pytest --pyargs compare_locales/tests compare_locales/parsers/tests compare_locales/resource/tests
 
 [testenv:flake8]
 basepython = python3.9


### PR DESCRIPTION
Adds
```py
from compare_locales.resource import resourceFromFluent, resourceFromProperties
```
along with data class definitions for a uniform representation of message resources as
```py
list[Comment | Message | Junk]
```

Constructors for other formats may be added later, as well as common linters and validators.