### PR TITLE
Warn if parameter counts don't match in Android strings

### DIFF
--- a/compare_locales/checks/android.py
+++ b/compare_locales/checks/android.py
@@ -59,11 +59,11 @@ class AndroidChecker(Checker):
             return
         yield from check_apostrophes(l10nEnt.val)
 
-        params, errors = get_params(refs)
+        params, count, errors = get_params(refs)
         for error, pos in errors:
             yield ("warning", pos, error, "android")
         if params:
-            yield from check_params(params, l10nEnt.val)
+            yield from check_params(params, count, l10nEnt.val)
 
     def not_translatable(self, *nodes):
         return any(
@@ -140,16 +140,18 @@ def check_apostrophes(string):
 def get_params(refs):
     """Get printf parameters and internal errors.
 
-    Returns a sparse map of positions to formatter, and a list
-    of errors. Errors covered so far are mismatching formatters.
+    Returns a sparse map of positions to formatter, parameter count and
+    a list of errors. Errors covered so far are mismatching formatters.
     """
     params = {}
     errors = []
+    count = 0
     next_implicit = 1
     for ref in refs:
         if isinstance(ref, minidom.Node):
             ref = textContent(ref)
         for m in re.finditer(r"%(?P<order>[1-9]\$)?(?P<format>[sSd])", ref):
+            count += 1
             order = m.group("order")
             if order:
                 order = int(order[0])
@@ -167,18 +169,20 @@ def get_params(refs):
                 errors.append(
                     (msg.format(order=order, f1=fmt, f2=params[order]), m.start())
                 )
-    return params, errors
+    return params, count, errors
 
 
-def check_params(params, string):
+def check_params(params, count, string):
     """Compare the printf parameters in the given string to the reference
     parameters.
 
     Also yields errors that are internal to the parameters inside string,
     as found by `get_params`.
     """
-    lparams, errors = get_params([string])
+    has_errors = False
+    lparams, lcount, errors = get_params([string])
     for error, pos in errors:
+        has_errors = True
         yield ("error", pos, error, "android")
     # Compare reference for each localized parameter.
     # If there's no reference found, error, as an out-of-bounds
@@ -188,6 +192,7 @@ def check_params(params, string):
     # If there's a mismatch in the formatter, error.
     for order in sorted(lparams):
         if order not in params:
+            has_errors = True
             yield (
                 "error",
                 0,
@@ -195,11 +200,13 @@ def check_params(params, string):
                 "android",
             )
         elif params[order] != lparams[order]:
+            has_errors = True
             yield ("error", 0, "Mismatching formatter", "android")
     # All parameters used in the reference are expected to be included.
     # Warn if this isn't the case.
     for order in params:
         if order not in sorted(lparams):
+            has_errors = True
             yield (
                 "warning",
                 0,
@@ -208,3 +215,5 @@ def check_params(params, string):
                 ),
                 "android",
             )
+    if not has_errors and count != lcount:
+        yield ("warning", 0, "Formatter count mismatch", "android")

--- a/compare_locales/tests/android/test_checks.py
+++ b/compare_locales/tests/android/test_checks.py
@@ -227,10 +227,10 @@ class PrintfCountOrderedTest(BaseHelper):
     refContent = ANDROID_WRAPPER % b"%1$s %2$s"
 
     def test_match(self):
-        self._test(ANDROID_WRAPPER % b'%1$s %2$s', tuple())
+        self._test(ANDROID_WRAPPER % b"%1$s %2$s", tuple())
 
     def test_count_too_high(self):
         self._test(
-            ANDROID_WRAPPER % b'%1$s %2$s %1$s %2$s',
+            ANDROID_WRAPPER % b"%1$s %2$s %1$s %2$s",
             (("warning", 0, "Formatter count mismatch", "android"),),
         )

--- a/compare_locales/tests/android/test_checks.py
+++ b/compare_locales/tests/android/test_checks.py
@@ -220,3 +220,17 @@ class PrintfCountNonOrderedTest(BaseHelper):
             ANDROID_WRAPPER % b"%s %s %s",
             (("error", 0, "Formatter %3$s not found in reference", "android"),),
         )
+
+
+class PrintfCountOrderedTest(BaseHelper):
+    file = File("values/strings.xml", "values/strings.xml")
+    refContent = ANDROID_WRAPPER % b"%1$s %2$s"
+
+    def test_match(self):
+        self._test(ANDROID_WRAPPER % b'%1$s %2$s', tuple())
+
+    def test_count_too_high(self):
+        self._test(
+            ANDROID_WRAPPER % b'%1$s %2$s %1$s %2$s',
+            (("warning", 0, "Formatter count mismatch", "android"),),
+        )

--- a/compare_locales/tests/android/test_checks.py
+++ b/compare_locales/tests/android/test_checks.py
@@ -200,3 +200,23 @@ class PrintfDTest(BaseHelper):
             ANDROID_WRAPPER % b'"% 1 $ d"',
             (("warning", 0, "Formatter %1$d not found in translation", "android"),),
         )
+
+
+class PrintfCountNonOrderedTest(BaseHelper):
+    file = File("values/strings.xml", "values/strings.xml")
+    refContent = ANDROID_WRAPPER % b"%s %s"
+
+    def test_match(self):
+        self._test(ANDROID_WRAPPER % b"%s %s", tuple())
+
+    def test_count_too_low(self):
+        self._test(
+            ANDROID_WRAPPER % b"%s",
+            (("warning", 0, "Formatter %2$s not found in translation", "android"),),
+        )
+
+    def test_count_too_high(self):
+        self._test(
+            ANDROID_WRAPPER % b"%s %s %s",
+            (("error", 0, "Formatter %3$s not found in reference", "android"),),
+        )


### PR DESCRIPTION
Fix #20.

The first commit just adds a missing test case. We already issue a warning if there is a count mismatch among non-ordered parameters (e.g. `%s`).

The second commit is the actual bugfix. We compare counts of ordered parameters (e.g. `%$1s`) between the reference string and the localized string and if there is a mismatch, we issue a warning.

I refrained from refactoring the code, because this is a temporary workaround.