### PR TITLE
Android: Include float printf with optional decimal precision in checks

### DIFF
--- a/compare_locales/checks/android.py
+++ b/compare_locales/checks/android.py
@@ -150,7 +150,9 @@ def get_params(refs):
     for ref in refs:
         if isinstance(ref, minidom.Node):
             ref = textContent(ref)
-        for m in re.finditer(r"%(?P<order>[1-9]\$)?(?P<format>[sSd])", ref):
+        for m in re.finditer(
+            r"%(?P<order>[1-9]\$)?(?P<format>(?:\.[0-9]+)?f|[dsS])", ref
+        ):
             count += 1
             order = m.group("order")
             if order:

--- a/compare_locales/resource/from_fluent.py
+++ b/compare_locales/resource/from_fluent.py
@@ -164,9 +164,11 @@ def messageFromFluentPattern(
     variants: List[Tuple[List[VariantKey], Pattern]] = [
         (
             [
-                CatchallKey(args[i].defaultName)
-                if k is None
-                else Literal(False, str(k))
+                (
+                    CatchallKey(args[i].defaultName)
+                    if k is None
+                    else Literal(False, str(k))
+                )
                 for i, k in enumerate(key)
             ],
             [],
@@ -193,17 +195,21 @@ def messageFromFluentPattern(
                     value = (
                         None
                         if v.default
-                        else v.key.name
-                        if isinstance(v.key, Fluent.Identifier)
-                        else v.key.value
+                        else (
+                            v.key.name
+                            if isinstance(v.key, Fluent.Identifier)
+                            else v.key.value
+                        )
                     )
                     addParts(v.value, filter + [(idx, value)])
             else:
                 for vk, vp in variants:
                     if all(
-                        value is None
-                        if isinstance(key, CatchallKey)
-                        else value == key.value
+                        (
+                            value is None
+                            if isinstance(key, CatchallKey)
+                            else value == key.value
+                        )
                         for key, value in map(lambda f: (vk[f[0]], f[1]), filter)
                     ):
                         last = vp[-1] if len(vp) else None

--- a/compare_locales/tests/android/test_checks.py
+++ b/compare_locales/tests/android/test_checks.py
@@ -166,7 +166,7 @@ class PrintfCapSTest(BaseHelper):
         )
 
 
-class PrintfDTest(BaseHelper):
+class PrintfIntegerTest(BaseHelper):
     file = File("values/strings.xml", "values/strings.xml")
     refContent = ANDROID_WRAPPER % b"%d"
 
@@ -199,6 +199,59 @@ class PrintfDTest(BaseHelper):
         self._test(
             ANDROID_WRAPPER % b'"% 1 $ d"',
             (("warning", 0, "Formatter %1$d not found in translation", "android"),),
+        )
+
+
+class PrintfFloatTest(BaseHelper):
+    file = File("values/strings.xml", "values/strings.xml")
+    refContent = ANDROID_WRAPPER % b"%f"
+
+    def test_match(self):
+        self._test(ANDROID_WRAPPER % b'"%f"', tuple())
+        self._test(ANDROID_WRAPPER % b'"%1$f"', tuple())
+        self._test(ANDROID_WRAPPER % b'"$f %1$f"', tuple())
+        self._test(ANDROID_WRAPPER % b'"$1$f %1$f"', tuple())
+
+    def test_mismatch(self):
+        self._test(
+            ANDROID_WRAPPER % b'"%s"',
+            (("error", 0, "Mismatching formatter", "android"),),
+        )
+        self._test(
+            ANDROID_WRAPPER % b'"%S"',
+            (("error", 0, "Mismatching formatter", "android"),),
+        )
+
+    def test_off_position(self):
+        self._test(
+            ANDROID_WRAPPER % b"%2$f",
+            (
+                ("error", 0, "Formatter %2$f not found in reference", "android"),
+                ("warning", 0, "Formatter %1$f not found in translation", "android"),
+            ),
+        )
+
+    def test_missing_placeholder(self):
+        self._test(
+            ANDROID_WRAPPER % b'"% 1 $ f"',
+            (("warning", 0, "Formatter %1$f not found in translation", "android"),),
+        )
+
+
+class PrintfFloatPrecisionTest(BaseHelper):
+    file = File("values/strings.xml", "values/strings.xml")
+    refContent = ANDROID_WRAPPER % b"%.02f"
+
+    def test_match(self):
+        self._test(ANDROID_WRAPPER % b'"%.02f"', tuple())
+        self._test(ANDROID_WRAPPER % b'"%1$.02f"', tuple())
+        self._test(ANDROID_WRAPPER % b'"$f %1$.02f"', tuple())
+        self._test(ANDROID_WRAPPER % b'"$1$.02f %1$.02f"', tuple())
+
+    def test_missing_placeholder(self):
+        self._test(
+            ANDROID_WRAPPER % b'"% 1 $ .02f"',
+            (("warning", 0, "Formatter %1$.02f not found in translation", "android"),),
         )
 
 


### PR DESCRIPTION
Not sure if this is the right or best approach, but I was reminded of this problem by the recent migration of `firefox-android` to `mozilla-central`.

We were hit by this [about a month ago](https://github.com/mozilla-mobile/firefox-android/pull/5608), where Google Translate changed `Rating: %1$.02f out of 5` to `Calificación:% 1 $ .02f de 5`.