### PR TITLE
Fluent: report range of lines for error on messages with attributes

### DIFF
--- a/compare_locales/lint/linter.py
+++ b/compare_locales/lint/linter.py
@@ -83,9 +83,9 @@ class EntityLinter:
                     "level": "warning",
                     "message": f"Changes to an existing string require a new ID: {current_entity.key}",
                 }
-                line_range = current_entity.report_range()
-                if line_range:
-                    res["lineoffset"] = line_range
+                line_offset = current_entity.line_offset()
+                if line_offset:
+                    res["lineoffset"] = line_offset
                 yield res
 
     def lint_value(self, current_entity):

--- a/compare_locales/lint/linter.py
+++ b/compare_locales/lint/linter.py
@@ -64,7 +64,7 @@ class EntityLinter:
         """
         lineno = col = None
         if self.key_count[current_entity.key] > 1:
-            lineno, col = current_entity.position()
+            lineno, col = current_entity.id_position()
             yield {
                 "lineno": lineno,
                 "column": col,
@@ -76,16 +76,17 @@ class EntityLinter:
             reference_entity = self.reference[current_entity.key]
             if not current_entity.equals(reference_entity):
                 if lineno is None:
-                    lineno, col = current_entity.position()
-                msg = "Changes to string require a new ID: {}".format(
-                    current_entity.key
-                )
-                yield {
+                    lineno, col = current_entity.id_position()
+                res = {
                     "lineno": lineno,
                     "column": col,
                     "level": "warning",
-                    "message": msg,
+                    "message": f"Changes to an existing string require a new ID: {current_entity.key}",
                 }
+                line_range = current_entity.report_range()
+                if line_range:
+                    res["lineoffset"] = line_range
+                yield res
 
     def lint_value(self, current_entity):
         """Checks that error on particular locations in the entity value."""

--- a/compare_locales/parser/base.py
+++ b/compare_locales/parser/base.py
@@ -85,7 +85,7 @@ class Entry:
         """
         return self.position()
 
-    def report_range(self):
+    def line_offset(self):
         """Return how many additional lines a full-entity warning should
         cover beyond 'id_position'.
 
@@ -95,7 +95,7 @@ class Entry:
 
         Defaults to 0, meaning the warning applies to a single line.
         Override for entities that can extend across several lines,
-        e.g. a Fluent message with attributes.
+        e.g. a multi-line Fluent message, or a message with attributes.
         """
         return 0
 

--- a/compare_locales/parser/base.py
+++ b/compare_locales/parser/base.py
@@ -74,6 +74,31 @@ class Entry:
             pos = self.val_span[0] + offset
         return self.ctx.linecol(pos)
 
+    def id_position(self):
+        """Return a 1-based (line, col) position indicating where the
+        identifier of this entity appears in the source file.
+
+        Defaults to the start of the entity span, which is correct for
+        most formats. Can be overridden when the entity span starts before
+        the identifier (e.g. in Fluent a message's span includes its leading
+        comment).
+        """
+        return self.position()
+
+    def report_range(self):
+        """Return how many additional lines a full-entity warning should
+        cover beyond 'id_position'.
+
+        This can be used to create a line range ('lineoffset' in mozlint),
+        allowing the warning to be displayed in Phabricator even when the
+        line with the entity ID is not part of the diff.
+
+        Defaults to 0, meaning the warning applies to a single line.
+        Override for entities that can extend across several lines,
+        e.g. a Fluent message with attributes.
+        """
+        return 0
+
     def _span_start(self):
         start = self.span[0]
         if hasattr(self, "pre_comment") and self.pre_comment is not None:

--- a/compare_locales/parser/fluent.py
+++ b/compare_locales/parser/fluent.py
@@ -111,12 +111,11 @@ class FluentEntity(Entity):
         # linter warnings.
         return self.ctx.linecol(self.key_span[0])
 
-    def report_range(self):
-        # Report 0, i.e. single line for value-only messages. When the message
-        # has attributes, extend the range to the last line of the
-        # entity, so the warning is associated with all parts of the message.
-        if not self.entry.attributes:
-            return 0
+    def line_offset(self):
+        # 0 (single line) for messages whose value fits on the ID line. For
+        # messages spanning several lines (multi-line value and/or attributes)
+        # extend the range to the last line of the entity, so the warning is
+        # associated with all parts of the message.
         end_lineno, _ = self.position(-1)
         id_lineno, _ = self.id_position()
         return end_lineno - id_lineno

--- a/compare_locales/parser/fluent.py
+++ b/compare_locales/parser/fluent.py
@@ -105,7 +105,23 @@ class FluentEntity(Entity):
     def equals(self, other):
         return self.entry.equals(other.entry, ignored_fields=self.ignored_fields)
 
-    # In Fluent we treat entries as a whole.  FluentChecker reports errors at
+    def id_position(self):
+        # Skip the leading comment: a Fluent message's span starts at the
+        # comment, but the identifier line is the meaningful reference for
+        # linter warnings.
+        return self.ctx.linecol(self.key_span[0])
+
+    def report_range(self):
+        # Report 0, i.e. single line for value-only messages. When the message
+        # has attributes, extend the range to the last line of the
+        # entity, so the warning is associated with all parts of the message.
+        if not self.entry.attributes:
+            return 0
+        end_lineno, _ = self.position(-1)
+        id_lineno, _ = self.id_position()
+        return end_lineno - id_lineno
+
+    # In Fluent we treat entries as a whole. FluentChecker reports errors at
     # offsets calculated from the beginning of the entry.
     def value_position(self, offset=None):
         if offset is None:

--- a/compare_locales/tests/lint/test_linter.py
+++ b/compare_locales/tests/lint/test_linter.py
@@ -92,3 +92,66 @@ one = two
         self.assertEqual(result["level"], "error")
         self.assertEqual(result["lineno"], 1)
         self.assertEqual(result["column"], 9)
+
+
+class FluentEntityTest(unittest.TestCase):
+    """Lint reporting behavior for Fluent messages."""
+
+    def _parse(self, source):
+        from compare_locales import parser as cl_parser
+
+        file_parser = cl_parser.getParser("foo.ftl")
+        file_parser.readUnicode(source)
+        return list(file_parser.parse())
+
+    def _ref(self, source):
+        return {e.key: e for e in self._parse(source)}
+
+    def test_value_only_change(self):
+        current = self._parse("# Comment\nmsg = new value\n")
+        reference = self._ref("# Comment\nmsg = old value\n")
+        el = linter.EntityLinter(current, None, reference)
+        results = list(el.lint_full_entity(current[0]))
+        self.assertEqual(len(results), 1)
+        result = results[0]
+        self.assertEqual(result["level"], "warning")
+        # ID line, not the comment line above
+        self.assertEqual(result["lineno"], 2)
+        self.assertEqual(result["column"], 1)
+        self.assertNotIn("lineoffset", result)
+
+    def test_attribute_change(self):
+        current = self._parse(
+            "# Comment\nmsg = value\n    .label = new\n    .title = also new\n"
+        )
+        reference = self._ref(
+            "# Comment\nmsg = value\n    .label = old\n    .title = also old\n"
+        )
+        el = linter.EntityLinter(current, None, reference)
+        results = list(el.lint_full_entity(current[0]))
+        self.assertEqual(len(results), 1)
+        result = results[0]
+        self.assertEqual(result["level"], "warning")
+        # ID line
+        self.assertEqual(result["lineno"], 2)
+        self.assertEqual(result["column"], 1)
+        # Spans both attribute lines (last attribute is line 4)
+        self.assertEqual(result["lineoffset"], 2)
+
+    def test_comment_only_change_no_warning(self):
+        current = self._parse("# New comment\nmsg = value\n")
+        reference = self._ref("# Old comment\nmsg = value\n")
+        el = linter.EntityLinter(current, None, reference)
+        results = list(el.lint_full_entity(current[0]))
+        self.assertEqual(results, [])
+
+    def test_duplicate_id_reports_at_id_line(self):
+        current = self._parse("# Comment\nmsg = one\nmsg = two\n")
+        el = linter.EntityLinter(current, None, {})
+        results = list(el.lint_full_entity(current[1]))
+        self.assertEqual(len(results), 1)
+        result = results[0]
+        self.assertEqual(result["level"], "error")
+        # Second definition is on line 3
+        self.assertEqual(result["lineno"], 3)
+        self.assertEqual(result["column"], 1)

--- a/compare_locales/tests/lint/test_linter.py
+++ b/compare_locales/tests/lint/test_linter.py
@@ -108,19 +108,47 @@ class FluentEntityTest(unittest.TestCase):
         return {e.key: e for e in self._parse(source)}
 
     def test_value_only_change(self):
+        # Single-line value: report on the ID line (line 2, not the comment
+        # above) with no lineoffset.
         current = self._parse("# Comment\nmsg = new value\n")
         reference = self._ref("# Comment\nmsg = old value\n")
         el = linter.EntityLinter(current, None, reference)
         results = list(el.lint_full_entity(current[0]))
-        self.assertEqual(len(results), 1)
-        result = results[0]
-        self.assertEqual(result["level"], "warning")
-        # ID line, not the comment line above
-        self.assertEqual(result["lineno"], 2)
-        self.assertEqual(result["column"], 1)
-        self.assertNotIn("lineoffset", result)
+        self.assertEqual(
+            results,
+            [
+                {
+                    "lineno": 2,
+                    "column": 1,
+                    "level": "warning",
+                    "message": "Changes to an existing string require a new ID: msg",
+                }
+            ],
+        )
+
+    def test_multiline_value_change(self):
+        # Multi-line value without attributes still spans several lines, so the
+        # warning must cover them via lineoffset (value ends on line 4).
+        current = self._parse("# Comment\nmsg =\n    line one\n    new two\n")
+        reference = self._ref("# Comment\nmsg =\n    line one\n    old two\n")
+        el = linter.EntityLinter(current, None, reference)
+        results = list(el.lint_full_entity(current[0]))
+        self.assertEqual(
+            results,
+            [
+                {
+                    "lineno": 2,
+                    "column": 1,
+                    "level": "warning",
+                    "message": "Changes to an existing string require a new ID: msg",
+                    "lineoffset": 2,
+                }
+            ],
+        )
 
     def test_attribute_change(self):
+        # ID line is 2, the last attribute is on line 4, so the warning spans
+        # both attribute lines via lineoffset.
         current = self._parse(
             "# Comment\nmsg = value\n    .label = new\n    .title = also new\n"
         )
@@ -129,14 +157,18 @@ class FluentEntityTest(unittest.TestCase):
         )
         el = linter.EntityLinter(current, None, reference)
         results = list(el.lint_full_entity(current[0]))
-        self.assertEqual(len(results), 1)
-        result = results[0]
-        self.assertEqual(result["level"], "warning")
-        # ID line
-        self.assertEqual(result["lineno"], 2)
-        self.assertEqual(result["column"], 1)
-        # Spans both attribute lines (last attribute is line 4)
-        self.assertEqual(result["lineoffset"], 2)
+        self.assertEqual(
+            results,
+            [
+                {
+                    "lineno": 2,
+                    "column": 1,
+                    "level": "warning",
+                    "message": "Changes to an existing string require a new ID: msg",
+                    "lineoffset": 2,
+                }
+            ],
+        )
 
     def test_comment_only_change_no_warning(self):
         current = self._parse("# New comment\nmsg = value\n")
@@ -146,12 +178,18 @@ class FluentEntityTest(unittest.TestCase):
         self.assertEqual(results, [])
 
     def test_duplicate_id_reports_at_id_line(self):
+        # Second definition is on line 3.
         current = self._parse("# Comment\nmsg = one\nmsg = two\n")
         el = linter.EntityLinter(current, None, {})
         results = list(el.lint_full_entity(current[1]))
-        self.assertEqual(len(results), 1)
-        result = results[0]
-        self.assertEqual(result["level"], "error")
-        # Second definition is on line 3
-        self.assertEqual(result["lineno"], 3)
-        self.assertEqual(result["column"], 1)
+        self.assertEqual(
+            results,
+            [
+                {
+                    "lineno": 3,
+                    "column": 1,
+                    "level": "error",
+                    "message": "Duplicate string with ID: msg",
+                }
+            ],
+        )


### PR DESCRIPTION
This is for https://bugzilla.mozilla.org/show_bug.cgi?id=1891657

There are probably more structural ways to approach this, but given the limited lifetime left for this linter, we shouldn't overinvest.

[This linter in firefox/main](https://github.com/mozilla-firefox/firefox/blob/b7b9235d7b58256a8b8a522c3577665c8ac5c9d3/tools/lint/clippy/__init__.py#L73) is already using `lineoffset`.