### PR TITLE
Update CI to fix failures, support Python 3.9–3.14

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/compare_locales/checks/__init__.py
+++ b/compare_locales/checks/__init__.py
@@ -8,7 +8,6 @@ from .dtd import DTDChecker
 from .fluent import FluentChecker
 from .properties import PropertiesChecker
 
-
 __all__ = [
     "Checker",
     "EntityPos",

--- a/compare_locales/checks/fluent.py
+++ b/compare_locales/checks/fluent.py
@@ -12,7 +12,6 @@ from fluent.syntax.visitor import Visitor
 from .base import Checker, CSSCheckMixin
 from compare_locales import plurals
 
-
 MSGS = {
     "missing-msg-ref": "Missing message reference: {ref}",
     "missing-term-ref": "Missing term reference: {ref}",

--- a/compare_locales/compare/__init__.py
+++ b/compare_locales/compare/__init__.py
@@ -13,7 +13,6 @@ from .content import ContentComparer
 from .observer import Observer, ObserverList
 from .utils import Tree, AddRemove
 
-
 __all__ = [
     "ContentComparer",
     "Observer",

--- a/compare_locales/integration_tests/test_plurals.py
+++ b/compare_locales/integration_tests/test_plurals.py
@@ -9,7 +9,6 @@ from urllib.request import urlopen
 
 from compare_locales import plurals
 
-
 TRANSVISION_URL = (
     "https://transvision.mozfr.org/"
     "api/v1/entity/gecko_strings/"

--- a/compare_locales/lint/cli.py
+++ b/compare_locales/lint/cli.py
@@ -16,7 +16,6 @@ from compare_locales import paths
 from compare_locales import parser
 from compare_locales import version
 
-
 epilog = """\
 moz-l10n-lint checks for common mistakes in localizable files. It tests for
 duplicate entries, parsing errors, and the like. Optionally, it can compare

--- a/compare_locales/mozpath.py
+++ b/compare_locales/mozpath.py
@@ -8,7 +8,6 @@ path separators (always use forward slashes).
 Also contains a few additional utilities not found in :py:mod:`os.path`.
 """
 
-
 import posixpath
 import os
 import re

--- a/compare_locales/parser/__init__.py
+++ b/compare_locales/parser/__init__.py
@@ -73,10 +73,16 @@ def getParser(path):
         if re.search(item[0], path):
             return item[1]
     try:
-        from pkg_resources import iter_entry_points
+        from importlib.metadata import entry_points
 
-        for entry_point in iter_entry_points("compare_locales.parsers"):
-            p = entry_point.resolve()()
+        eps = entry_points()
+        # Python 3.10+ returns a selectable object, earlier versions a dict.
+        if hasattr(eps, "select"):
+            parsers = eps.select(group="compare_locales.parsers")
+        else:
+            parsers = eps.get("compare_locales.parsers", [])
+        for entry_point in parsers:
+            p = entry_point.load()()
             if p.use(path):
                 return p
     except (ImportError, OSError):

--- a/compare_locales/parser/android.py
+++ b/compare_locales/parser/android.py
@@ -10,7 +10,6 @@ As we're using a built-in XML parser underneath, errors on that level
 break the full parsing, and result in a single Junk entry.
 """
 
-
 import re
 from xml.dom import minidom
 from xml.dom.minidom import Node

--- a/compare_locales/parser/base.py
+++ b/compare_locales/parser/base.py
@@ -339,7 +339,7 @@ class Parser:
 
         contents are in native encoding, but with normalized line endings.
         """
-        (contents, _) = codecs.getdecoder(self.encoding)(contents, "replace")
+        contents, _ = codecs.getdecoder(self.encoding)(contents, "replace")
         self.readUnicode(contents)
 
     def readUnicode(self, contents):

--- a/compare_locales/parser/dtd.py
+++ b/compare_locales/parser/dtd.py
@@ -56,18 +56,18 @@ class DTDParser(Parser):
     # | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] |
     # [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] |
     # [#x10000-#xEFFFF]
-    CharMinusDash = "\x09\x0A\x0D\u0020-\u002C\u002E-\uD7FF\uE000-\uFFFD"
+    CharMinusDash = "\x09\x0a\x0d\u0020-\u002c\u002e-\ud7ff\ue000-\ufffd"
     XmlComment = "<!--(?:-?[%s])*?-->" % CharMinusDash
     NameStartChar = (
-        ":A-Z_a-z\xC0-\xD6\xD8-\xF6\xF8-\u02FF"
-        + "\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F"
-        + "\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD"
+        ":A-Z_a-z\xc0-\xd6\xd8-\xf6\xf8-\u02ff"
+        + "\u0370-\u037d\u037f-\u1fff\u200c-\u200d\u2070-\u218f"
+        + "\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd"
     )
     # + \U00010000-\U000EFFFF seems to be unsupported in python
 
     # NameChar ::= NameStartChar | "-" | "." | [0-9] | #xB7 |
     #     [#x0300-#x036F] | [#x203F-#x2040]
-    NameChar = NameStartChar + r"\-\.0-9" + "\xB7\u0300-\u036F\u203F-\u2040"
+    NameChar = NameStartChar + r"\-\.0-9" + "\xb7\u0300-\u036f\u203f-\u2040"
     Name = "[" + NameStartChar + "][" + NameChar + "]*"
     reKey = re.compile(
         "<!ENTITY[ \t\r\n]+(?P<key>" + Name + ")[ \t\r\n]+"

--- a/compare_locales/parser/po.py
+++ b/compare_locales/parser/po.py
@@ -7,7 +7,6 @@
 Parses gettext po and pot files.
 """
 
-
 import re
 
 from .base import CAN_SKIP, Entity, BadEntity, Parser

--- a/compare_locales/paths/__init__.py
+++ b/compare_locales/paths/__init__.py
@@ -14,7 +14,6 @@ from .matcher import Matcher
 from .project import ProjectConfig
 from .configparser import TOMLParser, ConfigNotFound
 
-
 __all__ = [
     "Matcher",
     "ProjectConfig",

--- a/compare_locales/paths/files.py
+++ b/compare_locales/paths/files.py
@@ -5,7 +5,6 @@
 import os
 from compare_locales import mozpath
 
-
 REFERENCE_LOCALE = "en-x-moz-reference"
 
 

--- a/compare_locales/paths/matcher.py
+++ b/compare_locales/paths/matcher.py
@@ -7,7 +7,6 @@ import re
 import itertools
 from compare_locales import mozpath
 
-
 # Android uses non-standard locale codes, these are the mappings
 # back and forth
 ANDROID_LEGACY_MAP = {"he": "iw", "id": "in", "yi": "ji"}

--- a/compare_locales/tests/__init__.py
+++ b/compare_locales/tests/__init__.py
@@ -2,9 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""Mixins for parser tests.
-"""
-
+"""Mixins for parser tests."""
 
 from importlib.resources import files
 from itertools import zip_longest

--- a/compare_locales/tests/__init__.py
+++ b/compare_locales/tests/__init__.py
@@ -6,8 +6,8 @@
 """
 
 
+from importlib.resources import files
 from itertools import zip_longest
-from pkg_resources import resource_string
 import re
 import unittest
 
@@ -29,7 +29,7 @@ class ParserTestMixin:
         del self.parser
 
     def resource(self, name):
-        testcontent = resource_string(__name__, "data/" + name)
+        testcontent = files(__name__).joinpath("data", name).read_bytes()
         # fake universal line endings
         testcontent = re.sub(b"\r\n?", lambda m: b"\n", testcontent)
         return testcontent

--- a/compare_locales/tests/android/test_checks.py
+++ b/compare_locales/tests/android/test_checks.py
@@ -6,7 +6,6 @@
 from compare_locales.tests import BaseHelper
 from compare_locales.paths import File
 
-
 ANDROID_WRAPPER = b"""<?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="foo">%s</string>

--- a/compare_locales/tests/dtd/test_parser.py
+++ b/compare_locales/tests/dtd/test_parser.py
@@ -2,8 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""Tests for the DTD parser.
-"""
+"""Tests for the DTD parser."""
 
 import unittest
 import re
@@ -106,15 +105,13 @@ class TestDTD(ParserTestMixin, unittest.TestCase):
         self.assertEqual(e.key, "foo")
         self.assertEqual(e.val, "value")
         self.assertEqual(len(entities), 4)
-        p.readContents(
-            b"""\
+        p.readContents(b"""\
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this file,
    - You can obtain one at http://mozilla.org/MPL/2.0/.  -->
 
 <!ENTITY foo "value">
-"""
-        )
+""")
         entities = list(p.walk())
         self.assertIsInstance(entities[0], parser.Comment)
         self.assertIn("MPL", entities[0].all)
@@ -124,14 +121,12 @@ class TestDTD(ParserTestMixin, unittest.TestCase):
         self.assertEqual(e.val, "value")
         self.assertEqual(len(entities), 4)
         # Test again without empty line after licence header, and with BOM.
-        p.readContents(
-            b"""\xEF\xBB\xBF\
+        p.readContents(b"""\xef\xbb\xbf\
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this file,
    - You can obtain one at http://mozilla.org/MPL/2.0/.  -->
 <!ENTITY foo "value">
-"""
-        )
+""")
         entities = list(p.walk())
         self.assertIsInstance(entities[0], parser.Comment)
         self.assertIn("MPL", entities[0].all)
@@ -160,13 +155,11 @@ class TestDTD(ParserTestMixin, unittest.TestCase):
         self._test(" \n\n", ((Whitespace, " \n\n"),))
 
     def test_positions(self):
-        self.parser.readContents(
-            b"""\
+        self.parser.readContents(b"""\
 <!ENTITY one  "value">
 <!ENTITY  two "other
 escaped value">
-"""
-        )
+""")
         one, two = list(self.parser)
         self.assertEqual(one.position(), (1, 1))
         self.assertEqual(one.value_position(), (1, 16))
@@ -177,14 +170,12 @@ escaped value">
         self.assertEqual(two.value_position(10), (3, 5))
 
     def test_word_count(self):
-        self.parser.readContents(
-            b"""\
+        self.parser.readContents(b"""\
 <!ENTITY a "one">
 <!ENTITY b "one<br>two">
 <!ENTITY c "one<span>word</span>">
 <!ENTITY d "one <a href='foo'>two</a> three">
-"""
-        )
+""")
         a, b, c, d = list(self.parser)
         self.assertEqual(a.count_words(), 1)
         self.assertEqual(b.count_words(), 2)
@@ -192,15 +183,13 @@ escaped value">
         self.assertEqual(d.count_words(), 3)
 
     def test_html_entities(self):
-        self.parser.readContents(
-            b"""\
+        self.parser.readContents(b"""\
 <!ENTITY named "&amp;">
 <!ENTITY numcode "&#38;">
 <!ENTITY shorthexcode "&#x26;">
 <!ENTITY longhexcode "&#x0026;">
 <!ENTITY unknown "&unknownEntity;">
-"""
-        )
+""")
         entities = iter(self.parser)
 
         entity = next(entities)
@@ -224,14 +213,12 @@ escaped value">
         self.assertEqual(entity.val, "&unknownEntity;")
 
     def test_comment_val(self):
-        self.parser.readContents(
-            b"""\
+        self.parser.readContents(b"""\
 <!-- comment
 spanning lines -->  <!--
 -->
 <!-- last line -->
-"""
-        )
+""")
         entities = self.parser.walk()
 
         entity = next(entities)
@@ -253,16 +240,14 @@ spanning lines -->  <!--
         self.assertIsInstance(entity, parser.Whitespace)
 
     def test_pre_comment(self):
-        self.parser.readContents(
-            b"""\
+        self.parser.readContents(b"""\
 <!-- comment -->
 <!ENTITY one "string">
 
 <!-- standalone -->
 
 <!-- glued --><!ENTITY second "string">
-"""
-        )
+""")
         entities = self.parser.walk()
 
         entity = next(entities)

--- a/compare_locales/tests/fluent/test_checks.py
+++ b/compare_locales/tests/fluent/test_checks.py
@@ -41,25 +41,21 @@ class TestMessage(BaseHelper):
 
     def test_excess_attribute(self):
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             simple = value with
                 .obsolete = attribute
-            """
-            ),
+            """),
             (("error", 24, "Obsolete attribute: obsolete", "fluent"),),
         )
 
     def test_duplicate_attribute(self):
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             only-attr =
                 .one = attribute
                 .one = again
                 .one = three times
-            """
-            ),
+            """),
             (
                 ("warning", 16, 'Attribute "one" is duplicated', "fluent"),
                 ("warning", 37, 'Attribute "one" is duplicated', "fluent"),
@@ -69,11 +65,9 @@ class TestMessage(BaseHelper):
 
     def test_only_attributes(self):
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             only-attr = obsolete value
-            """
-            ),
+            """),
             (
                 ("error", 0, "Missing attribute: one", "fluent"),
                 ("error", 12, "Obsolete value", "fluent"),
@@ -82,12 +76,10 @@ class TestMessage(BaseHelper):
 
     def test_missing_value(self):
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             mixed-attr =
                 .and = attribute exists
-            """
-            ),
+            """),
             (("error", 0, "Missing value", "fluent"),),
         )
 
@@ -104,25 +96,21 @@ class TestTerm(BaseHelper):
 
     def test_mismatching_attribute(self):
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             -term = value with
                 .different = attribute
-            """
-            ),
+            """),
             tuple(),
         )
 
     def test_duplicate_attribute(self):
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             -term = need value
                 .one = attribute
                 .one = again
                 .one = three times
-            """
-            ),
+            """),
             (
                 ("warning", 23, 'Attribute "one" is duplicated', "fluent"),
                 ("warning", 44, 'Attribute "one" is duplicated', "fluent"),
@@ -163,23 +151,19 @@ class TestTermReference(BaseHelper):
 
     def test_good_term_ref(self):
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             term_ref = localized to {-term}
                 .attr = is plain
-            """
-            ),
+            """),
             tuple(),
         )
 
     def test_missing_term_ref(self):
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             term_ref = localized
                 .attr = should not refer to {-term}
-            """
-            ),
+            """),
             (
                 ("warning", 0, "Missing term reference: -term", "fluent"),
                 ("warning", 54, "Obsolete term reference: -term", "fluent"),
@@ -194,14 +178,12 @@ class TestTermReference(BaseHelper):
 
     def test_term_attr(self):
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             term_ref = Depends on { -term.prop ->
                 *[some] Term prop, doesn't reference the term value, though.
               }
               .attr = still simple
-            """
-            ),
+            """),
             (("warning", 0, "Missing term reference: -term", "fluent"),),
         )
 
@@ -220,27 +202,23 @@ msg = { $val ->
 
     def test_good(self):
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             msg = { $val ->
              *[one] one
               [other] other
               }
-            """
-            ),
+            """),
             tuple(),
         )
 
     def test_duplicate_variant(self):
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             msg = { $val ->
              *[one] one
               [one] other
               }
-            """
-            ),
+            """),
             (
                 ("warning", 19, 'Variant key "one" is duplicated', "fluent"),
                 ("warning", 31, 'Variant key "one" is duplicated', "fluent"),
@@ -249,15 +227,13 @@ msg = { $val ->
 
     def test_term_value(self):
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             -term = { PLATFORM() ->
              *[one] one
               [two] two
               [two] duplicate
               }
-            """
-            ),
+            """),
             (
                 ("warning", 39, 'Variant key "two" is duplicated', "fluent"),
                 ("warning", 51, 'Variant key "two" is duplicated', "fluent"),
@@ -266,8 +242,7 @@ msg = { $val ->
 
     def test_term_attribute(self):
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             -term = boring value
               .attr = { PLATFORM() ->
                *[one] one
@@ -275,8 +250,7 @@ msg = { $val ->
                 [two] duplicate
                 [two] three
                 }
-            """
-            ),
+            """),
             (
                 ("warning", 66, 'Variant key "two" is duplicated', "fluent"),
                 ("warning", 80, 'Variant key "two" is duplicated', "fluent"),
@@ -296,29 +270,25 @@ msg = { $val ->
     def test_missing_plural(self):
         self.file.locale = "ru"
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             msg = { $val ->
               [one] thing
               [3] is ok
              *[many] stuff
              }
-            """
-            ),
+            """),
             (("warning", 19, "Plural categories missing: few", "fluent"),),
         )
 
     def test_ignoring_other(self):
         self.file.locale = "de"
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             msg = { $val ->
               [1] thing
              *[other] stuff
              }
-            """
-            ),
+            """),
             tuple(),
         )
 
@@ -341,21 +311,17 @@ broken =
 
     def test_simple(self):
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             simple =
                 .style = width:2px
-            """
-            ),
+            """),
             tuple(),
         )
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             simple =
                 .style = max-width:2px
-            """
-            ),
+            """),
             (
                 (
                     "warning",
@@ -366,96 +332,78 @@ broken =
             ),
         )
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             simple =
                 .style = stuff
-            """
-            ),
+            """),
             (("error", 0, "reference is a CSS spec", "fluent"),),
         )
         # Cover the current limitations of only plain strings
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             simple =
                 .style = {"width:3px"}
-            """
-            ),
+            """),
             tuple(),
         )
 
     def test_select(self):
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             select =
                 .style = width:2px
-            """
-            ),
+            """),
             (("warning", 0, "width only in l10n", "fluent"),),
         )
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             select =
                 .style = max-width:2px
-            """
-            ),
+            """),
             (("warning", 0, "max-width only in l10n", "fluent"),),
         )
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             select =
                 .style = stuff
-            """
-            ),
+            """),
             (("error", 0, "reference is a CSS spec", "fluent"),),
         )
         # Cover the current limitations of only plain strings
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             select =
                 .style = {"width:1px"}
-            """
-            ),
+            """),
             tuple(),
         )
 
     def test_ref(self):
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             ref =
                 .style = width:2px
-            """
-            ),
+            """),
             (
                 ("warning", 0, "width only in l10n", "fluent"),
                 ("warning", 0, "Missing message reference: simple.style", "fluent"),
             ),
         )
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             ref =
                 .style = max-width:2px
-            """
-            ),
+            """),
             (
                 ("warning", 0, "max-width only in l10n", "fluent"),
                 ("warning", 0, "Missing message reference: simple.style", "fluent"),
             ),
         )
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             ref =
                 .style = stuff
-            """
-            ),
+            """),
             (
                 ("error", 0, "reference is a CSS spec", "fluent"),
                 ("warning", 0, "Missing message reference: simple.style", "fluent"),
@@ -463,32 +411,26 @@ broken =
         )
         # Cover the current limitations of only plain strings
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             ref =
                 .style = {"width:1px"}
-            """
-            ),
+            """),
             (("warning", 0, "Missing message reference: simple.style", "fluent"),),
         )
 
     def test_broken(self):
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             broken =
                 .style = 27em
-            """
-            ),
+            """),
             (("error", 0, "reference is a CSS spec", "fluent"),),
         )
         self._test(
-            dedent_ftl(
-                """\
+            dedent_ftl("""\
             broken =
                 .style = width: 27em
-            """
-            ),
+            """),
             (("warning", 0, "width only in l10n", "fluent"),),
         )
 

--- a/compare_locales/tests/fluent/test_parser.py
+++ b/compare_locales/tests/fluent/test_parser.py
@@ -37,8 +37,7 @@ class TestFluentParser(ParserTestMixin, unittest.TestCase):
         self.assertTrue(ent1.equals(ent2))
 
     def test_word_count(self):
-        self.parser.readContents(
-            b"""\
+        self.parser.readContents(b"""\
 a = One
 b = One two three
 c = One { $arg } two
@@ -66,8 +65,7 @@ h =
         } ten.
 -i = One
   .prop = Do not count
-"""
-        )
+""")
 
         a, b, c, d, e, f, g, h, i = list(self.parser)
         self.assertEqual(a.count_words(), 1)
@@ -99,14 +97,12 @@ h =
         self.assertEqual(abc.all, "abc = A { $arg } B { msg } C")
 
     def test_multiline_message(self):
-        self.parser.readContents(
-            b"""\
+        self.parser.readContents(b"""\
 abc =
     A
     B
     C
-"""
-        )
+""")
 
         [abc] = list(self.parser)
         self.assertEqual(abc.key, "abc")
@@ -114,14 +110,12 @@ abc =
         self.assertEqual(abc.all, "abc =\n    A\n    B\n    C")
 
     def test_message_with_attribute(self):
-        self.parser.readContents(
-            b"""\
+        self.parser.readContents(b"""\
 
 
 abc = ABC
     .attr = Attr
-"""
-        )
+""")
 
         [abc] = list(self.parser)
         self.assertEqual(abc.key, "abc")
@@ -133,12 +127,10 @@ abc = ABC
         self.assertEqual(attr.value_position(), (4, 13))
 
     def test_message_with_attribute_and_no_value(self):
-        self.parser.readContents(
-            b"""\
+        self.parser.readContents(b"""\
 abc =
     .attr = Attr
-"""
-        )
+""")
 
         [abc] = list(self.parser)
         self.assertEqual(abc.key, "abc")
@@ -153,8 +145,7 @@ abc =
         self.assertEqual(attr.value_position(), (2, 13))
 
     def test_non_localizable(self):
-        self.parser.readContents(
-            b"""\
+        self.parser.readContents(b"""\
 ### Resource Comment
 
 foo = Foo
@@ -169,8 +160,7 @@ foo = Foo
 
 # Baz Comment
 baz = Baz
-"""
-        )
+""")
         entities = self.parser.walk()
 
         entity = next(entities)
@@ -234,8 +224,7 @@ baz = Baz
             next(entities)
 
     def test_comments_val(self):
-        self.parser.readContents(
-            b"""\
+        self.parser.readContents(b"""\
 // Legacy Comment
 
 ### Resource Comment
@@ -243,8 +232,7 @@ baz = Baz
 ## Section Comment
 
 # Standalone Comment
-"""
-        )
+""")
         entities = self.parser.walk()
 
         entity = next(entities)
@@ -281,16 +269,14 @@ baz = Baz
             next(entities)
 
     def test_junk(self):
-        self.parser.readUnicode(
-            """\
+        self.parser.readUnicode("""\
 # Comment
 
 Line of junk
 
 # Comment
 msg = value
-"""
-        )
+""")
         entities = self.parser.walk()
 
         entity = next(entities)

--- a/compare_locales/tests/lint/test_linter.py
+++ b/compare_locales/tests/lint/test_linter.py
@@ -29,13 +29,11 @@ class EntityTest(unittest.TestCase):
         self.assertIsNone(el.handle_junk(ent))
 
     def test_full_entity(self):
-        ctx = parser.Parser.Context(
-            """\
+        ctx = parser.Parser.Context("""\
 one = two
 two = three
 one = four
-"""
-        )
+""")
         entities = [
             parser.Entity(ctx, None, None, (0, 10), (0, 3), (6, 9)),
             parser.Entity(ctx, None, None, (10, 22), (10, 13), (16, 21)),
@@ -72,11 +70,9 @@ one = four
         self.assertEqual(result["column"], 1)
 
     def test_in_value(self):
-        ctx = parser.Parser.Context(
-            """\
+        ctx = parser.Parser.Context("""\
 one = two
-"""
-        )
+""")
         entities = [
             parser.Entity(ctx, None, None, (0, 10), (0, 3), (6, 9)),
         ]

--- a/compare_locales/tests/properties/test_parser.py
+++ b/compare_locales/tests/properties/test_parser.py
@@ -67,15 +67,15 @@ and still has another line coming
         ref = [
             "abc",
             "xy",
-            "\u1234\t\r\n\u00AB\u0001\n",
+            "\u1234\t\r\n\u00ab\u0001\n",
             "this is multiline property",
             "this is another multiline property",
             "test\u0036",
             "yet another multiline propery",
             "\ttest5\u0020",
             " test6\t",
-            "c\uCDEFd",
-            "\uABCD",
+            "c\ucdefd",
+            "\uabcd",
         ]
         i = iter(self.parser)
         for r, e in zip(ref, i):
@@ -112,8 +112,7 @@ foo=value
         )
 
     def test_escapes(self):
-        self.parser.readContents(
-            rb"""
+        self.parser.readContents(rb"""
 # unicode escapes
 zero = some \unicode
 one = \u0
@@ -123,8 +122,7 @@ four = \u0043
 five = \u0044a
 six = \a
 seven = \n\r\t\\
-"""
-        )
+""")
         ref = ["some unicode", chr(0), "A", "B", "C", "Da", "a", "\n\r\t\\"]
         for r, e in zip(ref, self.parser):
             self.assertEqual(e.val, r)
@@ -222,13 +220,11 @@ foo = value
         self._test(" \n\n", ((Whitespace, "\n\n"),))
 
     def test_positions(self):
-        self.parser.readContents(
-            b"""\
+        self.parser.readContents(b"""\
 one = value
 two = other \\
 escaped value
-"""
-        )
+""")
         one, two = list(self.parser)
         self.assertEqual(one.position(), (1, 1))
         self.assertEqual(one.value_position(), (1, 7))
@@ -239,11 +235,9 @@ escaped value
 
     # Bug 1399059 comment 18
     def test_z(self):
-        self.parser.readContents(
-            b"""\
+        self.parser.readContents(b"""\
 one = XYZ ABC
-"""
-        )
+""")
         (one,) = list(self.parser)
         self.assertEqual(one.val, "XYZ ABC")
 

--- a/compare_locales/tests/serializer/test_android.py
+++ b/compare_locales/tests/serializer/test_android.py
@@ -56,13 +56,11 @@ class TestAndroidSerializer(Helper, unittest.TestCase):
     def test_new_cdata(self):
         self._test(
             "",
-            {
-                "message": """
+            {"message": """
 <ul>
   <li>Something else</li>
 </ul>
-"""
-            },
+"""},
             """\
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
@@ -78,13 +76,11 @@ class TestAndroidSerializer(Helper, unittest.TestCase):
     def test_new_cdata_wrapped(self):
         self._test(
             "",
-            {
-                "wrapped_message": """
+            {"wrapped_message": """
 <ul>
   <li>Something else</li>
 </ul>
-"""
-            },
+"""},
             """\
 <?xml version="1.0" encoding="utf-8"?>
 <resources>

--- a/compare_locales/tests/test_defines.py
+++ b/compare_locales/tests/test_defines.py
@@ -13,7 +13,6 @@ from compare_locales.parser import (
     Whitespace,
 )
 
-
 mpl2 = """\
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
@@ -25,8 +24,7 @@ class TestDefinesParser(ParserTestMixin, unittest.TestCase):
 
     def testBrowser(self):
         self._test(
-            mpl2
-            + """
+            mpl2 + """
 #filter emptyLines
 
 #define MOZ_LANGPACK_CREATOR mozilla.org
@@ -54,8 +52,7 @@ class TestDefinesParser(ParserTestMixin, unittest.TestCase):
 
     def testBrowserWithContributors(self):
         self._test(
-            mpl2
-            + """
+            mpl2 + """
 #filter emptyLines
 
 #define MOZ_LANGPACK_CREATOR mozilla.org
@@ -87,8 +84,7 @@ class TestDefinesParser(ParserTestMixin, unittest.TestCase):
 
     def testCommentWithNonAsciiCharacters(self):
         self._test(
-            mpl2
-            + """
+            mpl2 + """
 #filter emptyLines
 
 # e.g. #define seamonkey_l10n <DT><A HREF="urn:foo">SeaMonkey v češtině</a>

--- a/compare_locales/tests/test_ini.py
+++ b/compare_locales/tests/test_ini.py
@@ -13,7 +13,6 @@ from compare_locales.parser import (
     Whitespace,
 )
 
-
 mpl2 = """\
 ; This Source Code Form is subject to the terms of the Mozilla Public
 ; License, v. 2.0. If a copy of the MPL was not distributed with this file,
@@ -41,8 +40,7 @@ TitleText=Some Title
 
     def testMPL2_Space_UTF(self):
         self._test(
-            mpl2
-            + """
+            mpl2 + """
 
 ; This file is in the UTF-8 encoding
 [Strings]
@@ -62,8 +60,7 @@ TitleText=Some Title
 
     def testMPL2_Space(self):
         self._test(
-            mpl2
-            + """
+            mpl2 + """
 
 [Strings]
 TitleText=Some Title
@@ -80,8 +77,7 @@ TitleText=Some Title
 
     def testMPL2_no_space(self):
         self._test(
-            mpl2
-            + """
+            mpl2 + """
 [Strings]
 TitleText=Some Title
 """,
@@ -97,8 +93,7 @@ TitleText=Some Title
 
     def testMPL2_MultiSpace(self):
         self._test(
-            mpl2
-            + """
+            mpl2 + """
 
 ; more comments
 
@@ -119,8 +114,7 @@ TitleText=Some Title
 
     def testMPL2_JunkBeforeCategory(self):
         self._test(
-            mpl2
-            + """
+            mpl2 + """
 Junk
 [Strings]
 TitleText=Some Title
@@ -138,8 +132,7 @@ TitleText=Some Title
 
     def test_TrailingComment(self):
         self._test(
-            mpl2
-            + """
+            mpl2 + """
 
 [Strings]
 TitleText=Some Title
@@ -159,8 +152,7 @@ TitleText=Some Title
 
     def test_SpacedTrailingComments(self):
         self._test(
-            mpl2
-            + """
+            mpl2 + """
 
 [Strings]
 TitleText=Some Title
@@ -183,8 +175,7 @@ TitleText=Some Title
 
     def test_TrailingCommentsAndJunk(self):
         self._test(
-            mpl2
-            + """
+            mpl2 + """
 
 [Strings]
 TitleText=Some Title
@@ -211,8 +202,7 @@ Junk
 
     def test_JunkInbetweenEntries(self):
         self._test(
-            mpl2
-            + """
+            mpl2 + """
 
 [Strings]
 TitleText=Some Title

--- a/compare_locales/tests/test_keyedtuple.py
+++ b/compare_locales/tests/test_keyedtuple.py
@@ -8,7 +8,6 @@ import unittest
 
 from compare_locales.keyedtuple import KeyedTuple
 
-
 KeyedThing = namedtuple("KeyedThing", ["key", "val"])
 
 

--- a/compare_locales/tests/test_merge.py
+++ b/compare_locales/tests/test_merge.py
@@ -116,26 +116,22 @@ class TestDefines(unittest.TestCase, ContentMixin):
 
     def testGood(self):
         self.assertTrue(os.path.isdir(self.tmp))
-        self.reference(
-            """#filter emptyLines
+        self.reference("""#filter emptyLines
 
 #define MOZ_LANGPACK_CREATOR mozilla.org
 
 #define MOZ_LANGPACK_CONTRIBUTORS <em:contributor>Suzy Solon</em:contributor>
 
 #unfilter emptyLines
-"""
-        )
-        self.localized(
-            """#filter emptyLines
+""")
+        self.localized("""#filter emptyLines
 
 #define MOZ_LANGPACK_CREATOR mozilla.org
 
 #define MOZ_LANGPACK_CONTRIBUTORS <em:contributor>Jane Doe</em:contributor>
 
 #unfilter emptyLines
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -170,24 +166,20 @@ class TestDefines(unittest.TestCase, ContentMixin):
 
     def testMissing(self):
         self.assertTrue(os.path.isdir(self.tmp))
-        self.reference(
-            """#filter emptyLines
+        self.reference("""#filter emptyLines
 
 #define MOZ_LANGPACK_CREATOR mozilla.org
 
 #define MOZ_LANGPACK_CONTRIBUTORS <em:contributor>Suzy Solon</em:contributor>
 
 #unfilter emptyLines
-"""
-        )
-        self.localized(
-            """#filter emptyLines
+""")
+        self.localized("""#filter emptyLines
 
 #define MOZ_LANGPACK_CREATOR mozilla.org
 
 #unfilter emptyLines
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -237,17 +229,13 @@ class TestProperties(unittest.TestCase, ContentMixin):
 
     def testGood(self):
         self.assertTrue(os.path.isdir(self.tmp))
-        self.reference(
-            """foo = fooVal word
+        self.reference("""foo = fooVal word
 bar = barVal word
-eff = effVal"""
-        )
-        self.localized(
-            """foo = lFoo
+eff = effVal""")
+        self.localized("""foo = lFoo
 bar = lBar
 eff = lEff word
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -282,15 +270,11 @@ eff = lEff word
 
     def testMissing(self):
         self.assertTrue(os.path.isdir(self.tmp))
-        self.reference(
-            """foo = fooVal
+        self.reference("""foo = fooVal
 bar = barVal
-eff = effVal"""
-        )
-        self.localized(
-            """bar = lBar
-"""
-        )
+eff = effVal""")
+        self.localized("""bar = lBar
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -333,11 +317,9 @@ eff = effVal"""
 
     def test_missing_file(self):
         self.assertTrue(os.path.isdir(self.tmp))
-        self.reference(
-            """foo = fooVal
+        self.reference("""foo = fooVal
 bar = barVal
-eff = effVal"""
-        )
+eff = effVal""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.add(
@@ -371,17 +353,13 @@ eff = effVal"""
 
     def testError(self):
         self.assertTrue(os.path.isdir(self.tmp))
-        self.reference(
-            """foo = fooVal
+        self.reference("""foo = fooVal
 bar = %d barVal
-eff = effVal"""
-        )
-        self.localized(
-            """\
+eff = effVal""")
+        self.localized("""\
 bar = %S lBar
 eff = leffVal
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -428,16 +406,12 @@ eff = leffVal
 
     def testObsolete(self):
         self.assertTrue(os.path.isdir(self.tmp))
-        self.reference(
-            """foo = fooVal
-eff = effVal"""
-        )
-        self.localized(
-            """foo = fooVal
+        self.reference("""foo = fooVal
+eff = effVal""")
+        self.localized("""foo = fooVal
 other = obsolete
 eff = leffVal
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -471,11 +445,9 @@ eff = leffVal
 
     def test_obsolete_file(self):
         self.assertTrue(os.path.isdir(self.tmp))
-        self.localized(
-            """foo = fooVal
+        self.localized("""foo = fooVal
 eff = leffVal
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.remove(
@@ -495,19 +467,15 @@ eff = leffVal
 
     def test_duplicate(self):
         self.assertTrue(os.path.isdir(self.tmp))
-        self.reference(
-            """foo = fooVal
+        self.reference("""foo = fooVal
 bar = barVal
 eff = effVal
-foo = other val for foo"""
-        )
-        self.localized(
-            """foo = localized
+foo = other val for foo""")
+        self.localized("""foo = localized
 bar = lBar
 eff = localized eff
 bar = duplicated bar
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -559,17 +527,13 @@ class TestDTD(unittest.TestCase, ContentMixin):
 
     def testGood(self):
         self.assertTrue(os.path.isdir(self.tmp))
-        self.reference(
-            """<!ENTITY foo 'fooVal'>
+        self.reference("""<!ENTITY foo 'fooVal'>
 <!ENTITY bar 'barVal'>
-<!ENTITY eff 'effVal'>"""
-        )
-        self.localized(
-            """<!ENTITY foo 'lFoo'>
+<!ENTITY eff 'effVal'>""")
+        self.localized("""<!ENTITY foo 'lFoo'>
 <!ENTITY bar 'lBar'>
 <!ENTITY eff 'lEff'>
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -604,15 +568,11 @@ class TestDTD(unittest.TestCase, ContentMixin):
 
     def testMissing(self):
         self.assertTrue(os.path.isdir(self.tmp))
-        self.reference(
-            """<!ENTITY foo 'fooVal'>
+        self.reference("""<!ENTITY foo 'fooVal'>
 <!ENTITY bar 'barVal'>
-<!ENTITY eff 'effVal'>"""
-        )
-        self.localized(
-            """<!ENTITY bar 'lBar'>
-"""
-        )
+<!ENTITY eff 'effVal'>""")
+        self.localized("""<!ENTITY bar 'lBar'>
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -652,17 +612,13 @@ class TestDTD(unittest.TestCase, ContentMixin):
 
     def testJunk(self):
         self.assertTrue(os.path.isdir(self.tmp))
-        self.reference(
-            """<!ENTITY foo 'fooVal'>
+        self.reference("""<!ENTITY foo 'fooVal'>
 <!ENTITY bar 'barVal'>
-<!ENTITY eff 'effVal'>"""
-        )
-        self.localized(
-            """<!ENTITY foo 'fooVal'>
+<!ENTITY eff 'effVal'>""")
+        self.localized("""<!ENTITY foo 'fooVal'>
 <!ENTY bar 'gimmick'>
 <!ENTITY eff 'effVal'>
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -710,16 +666,12 @@ class TestDTD(unittest.TestCase, ContentMixin):
 
     def test_reference_junk(self):
         self.assertTrue(os.path.isdir(self.tmp))
-        self.reference(
-            """<!ENTITY foo 'fooVal'>
+        self.reference("""<!ENTITY foo 'fooVal'>
 <!ENT bar 'bad val'>
-<!ENTITY eff 'effVal'>"""
-        )
-        self.localized(
-            """<!ENTITY foo 'fooVal'>
+<!ENTITY eff 'effVal'>""")
+        self.localized("""<!ENTITY foo 'fooVal'>
 <!ENTITY eff 'effVal'>
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -753,17 +705,13 @@ class TestDTD(unittest.TestCase, ContentMixin):
 
     def test_reference_xml_error(self):
         self.assertTrue(os.path.isdir(self.tmp))
-        self.reference(
-            """<!ENTITY foo 'fooVal'>
+        self.reference("""<!ENTITY foo 'fooVal'>
 <!ENTITY bar 'bad &val'>
-<!ENTITY eff 'effVal'>"""
-        )
-        self.localized(
-            """<!ENTITY foo 'fooVal'>
+<!ENTITY eff 'effVal'>""")
+        self.localized("""<!ENTITY foo 'fooVal'>
 <!ENTITY bar 'good val'>
 <!ENTITY eff 'effVal'>
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -828,20 +776,16 @@ class TestFluent(unittest.TestCase):
         del self.l10n
 
     def testGood(self):
-        self.reference(
-            """\
+        self.reference("""\
 foo = fooVal
 bar = barVal
 -eff = effVal
-"""
-        )
-        self.localized(
-            """\
+""")
+        self.localized("""\
 foo = lFoo
 bar = lBar
 -eff = lEff
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -877,20 +821,16 @@ bar = lBar
         self.assertTrue(filecmp.cmp(self.l10n, mergepath))
 
     def testMissing(self):
-        self.reference(
-            """\
+        self.reference("""\
 foo = fooVal
 bar = barVal
 -baz = bazVal
 eff = effVal
-"""
-        )
-        self.localized(
-            """\
+""")
+        self.localized("""\
 foo = lFoo
 eff = lEff
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -931,21 +871,17 @@ eff = lEff
         self.assertTrue(filecmp.cmp(self.l10n, mergepath))
 
     def testBroken(self):
-        self.reference(
-            """\
+        self.reference("""\
 foo = fooVal
 bar = barVal
 eff = effVal
-"""
-        )
-        self.localized(
-            """\
+""")
+        self.localized("""\
 -- Invalid Comment
 foo = lFoo
 bar lBar
 eff = lEff {
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -1013,16 +949,12 @@ eff = lEff {
         self.assertTrue(merged_foo.equals(l10n_foo))
 
     def testMatchingReferences(self):
-        self.reference(
-            """\
+        self.reference("""\
 foo = Reference { bar }
-"""
-        )
-        self.localized(
-            """\
+""")
+        self.localized("""\
 foo = Localized { bar }
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -1058,20 +990,16 @@ foo = Localized { bar }
         self.assertTrue(filecmp.cmp(self.l10n, mergepath))
 
     def testMismatchingReferences(self):
-        self.reference(
-            """\
+        self.reference("""\
 foo = Reference { bar }
 bar = Reference { baz }
 baz = Reference
-"""
-        )
-        self.localized(
-            """\
+""")
+        self.localized("""\
 foo = Localized { qux }
 bar = Localized
 baz = Localized { qux }
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -1126,22 +1054,18 @@ baz = Localized { qux }
         self.assertTrue(filecmp.cmp(self.l10n, mergepath))
 
     def testMismatchingAttributes(self):
-        self.reference(
-            """
+        self.reference("""
 foo = Foo
 bar = Bar
   .tender = Attribute value
 eff = Eff
-"""
-        )
-        self.localized(
-            """\
+""")
+        self.localized("""\
 foo = lFoo
   .obsolete = attr
 bar = lBar
 eff = lEff
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -1200,8 +1124,7 @@ eff = lEff
         self.assertTrue(merged_eff.equals(l10n_eff))
 
     def test_term_attributes(self):
-        self.reference(
-            """
+        self.reference("""
 -foo = Foo
 -bar = Bar
 -baz = Baz
@@ -1210,18 +1133,15 @@ eff = lEff
     .attr = Qux Attribute
 -missing = Missing
     .attr = An Attribute
-"""
-        )
-        self.localized(
-            """\
+""")
+        self.localized("""\
 -foo = Localized Foo
 -bar = Localized Bar
     .attr = Locale-specific Bar Attribute
 -baz = Localized Baz
 -qux = Localized Qux
     .other = Locale-specific Qux Attribute
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -1261,22 +1181,18 @@ eff = lEff
         self.assertTrue(filecmp.cmp(self.l10n, mergepath))
 
     def testMismatchingValues(self):
-        self.reference(
-            """
+        self.reference("""
 foo = Foo
   .foottr = something
 bar =
   .tender = Attribute value
-"""
-        )
-        self.localized(
-            """\
+""")
+        self.localized("""\
 foo =
   .foottr = attr
 bar = lBar
   .tender = localized
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -1324,20 +1240,16 @@ bar = lBar
         self.assertEqual(merged_entities, tuple())
 
     def testMissingGroupComment(self):
-        self.reference(
-            """\
+        self.reference("""\
 foo = fooVal
 
 ## Group Comment
 bar = barVal
-"""
-        )
-        self.localized(
-            """\
+""")
+        self.localized("""\
 foo = lFoo
 bar = lBar
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -1373,20 +1285,16 @@ bar = lBar
         self.assertTrue(filecmp.cmp(self.l10n, mergepath))
 
     def testMissingAttachedComment(self):
-        self.reference(
-            """\
+        self.reference("""\
 foo = fooVal
 
 # Attached Comment
 bar = barVal
-"""
-        )
-        self.localized(
-            """\
+""")
+        self.localized("""\
 foo = lFoo
 bar = barVal
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -1422,21 +1330,17 @@ bar = barVal
         self.assertTrue(filecmp.cmp(self.l10n, mergepath))
 
     def testObsoleteStandaloneComment(self):
-        self.reference(
-            """\
+        self.reference("""\
 foo = fooVal
 bar = barVal
-"""
-        )
-        self.localized(
-            """\
+""")
+        self.localized("""\
 foo = lFoo
 
 # Standalone Comment
 
 bar = lBar
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -1473,19 +1377,15 @@ bar = lBar
 
     def test_duplicate(self):
         self.assertTrue(os.path.isdir(self.tmp))
-        self.reference(
-            """foo = fooVal
+        self.reference("""foo = fooVal
 bar = barVal
 eff = effVal
-foo = other val for foo"""
-        )
-        self.localized(
-            """foo = localized
+foo = other val for foo""")
+        self.localized("""foo = localized
 bar = lBar
 eff = localized eff
 bar = duplicated bar
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(
@@ -1524,17 +1424,13 @@ bar = duplicated bar
 
     def test_duplicate_attributes(self):
         self.assertTrue(os.path.isdir(self.tmp))
-        self.reference(
-            """foo = fooVal
-    .attr = good"""
-        )
-        self.localized(
-            """foo = localized
+        self.reference("""foo = fooVal
+    .attr = good""")
+        self.localized("""foo = localized
     .attr = not
     .attr = so
     .attr = good
-"""
-        )
+""")
         cc = ContentComparer()
         cc.observers.append(Observer())
         cc.compare(

--- a/compare_locales/tests/test_parser.py
+++ b/compare_locales/tests/test_parser.py
@@ -15,12 +15,10 @@ from compare_locales import parser, mozpath
 class TestParserContext(unittest.TestCase):
     def test_linecol(self):
         "Should return 1-based line and column numbers."
-        ctx = parser.Parser.Context(
-            """first line
+        ctx = parser.Parser.Context("""first line
 second line
 third line
-"""
-        )
+""")
         self.assertEqual(ctx.linecol(0), (1, 1))
         self.assertEqual(ctx.linecol(1), (1, 2))
         self.assertEqual(ctx.linecol(len("first line")), (1, len("first line") + 1))
@@ -35,25 +33,19 @@ third line
 
 class TestOffsetComment(unittest.TestCase):
     def test_offset(self):
-        ctx = parser.Parser.Context(
-            textwrap.dedent(
-                """\
+        ctx = parser.Parser.Context(textwrap.dedent("""\
             #foo
             #bar
             # baz
-            """
-            )
-        )  # noqa
+            """))  # noqa
         offset_comment = parser.OffsetComment(ctx, (0, len(ctx.contents)))
         self.assertEqual(
             offset_comment.val,
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
                 foo
                 bar
                  baz
-            """
-            ),
+            """),
         )
 
 

--- a/compare_locales/tests/test_parser.py
+++ b/compare_locales/tests/test_parser.py
@@ -2,11 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import pkg_resources
+from importlib.metadata import EntryPoint
 import shutil
 import tempfile
 import textwrap
 import unittest
+from unittest import mock
 
 from compare_locales import parser, mozpath
 
@@ -77,17 +78,21 @@ class TestUniversalNewlines(unittest.TestCase):
 
 class TestPlugins(unittest.TestCase):
     def setUp(self):
-        self.old_working_set_state = pkg_resources.working_set.__getstate__()
-        distribution = pkg_resources.Distribution(__file__)
-        entry_point = pkg_resources.EntryPoint.parse(
-            "test_parser = compare_locales.tests.test_parser:DummyParser",
-            dist=distribution,
+        entry_point = EntryPoint(
+            name="test_parser",
+            value="compare_locales.tests.test_parser:DummyParser",
+            group="compare_locales.parsers",
         )
-        distribution._ep_map = {"compare_locales.parsers": {"test_parser": entry_point}}
-        pkg_resources.working_set.add(distribution)
+        # Returning a dict exercises the non-selectable code path in
+        # getParser, which works regardless of the Python version.
+        self.patcher = mock.patch(
+            "importlib.metadata.entry_points",
+            return_value={"compare_locales.parsers": [entry_point]},
+        )
+        self.patcher.start()
 
     def tearDown(self):
-        pkg_resources.working_set.__setstate__(self.old_working_set_state)
+        self.patcher.stop()
 
     def test_dummy_parser(self):
         p = parser.getParser("some/weird/file.ext")

--- a/compare_locales/tests/test_util.py
+++ b/compare_locales/tests/test_util.py
@@ -13,32 +13,26 @@ class ParseLocalesTest(unittest.TestCase):
 
     def test_all(self):
         self.assertEqual(
-            util.parseLocales(
-                """af
-de"""
-            ),
+            util.parseLocales("""af
+de"""),
             ["af", "de"],
         )
 
     def test_shipped(self):
         self.assertEqual(
-            util.parseLocales(
-                """af
+            util.parseLocales("""af
 ja win mac
-de"""
-            ),
+de"""),
             ["af", "de", "ja"],
         )
 
     def test_sparse(self):
         self.assertEqual(
-            util.parseLocales(
-                """
+            util.parseLocales("""
 af
 
 de
 
-"""
-            ),
+"""),
             ["af", "de"],
         )

--- a/contrib/lang/src/cl_ext/lang/lang.py
+++ b/contrib/lang/src/cl_ext/lang/lang.py
@@ -10,7 +10,6 @@ from parsimonious.nodes import NodeVisitor
 from compare_locales.parser.base import Comment, LiteralEntity, Junk, Parser
 from compare_locales.paths import File
 
-
 BLANK_LINE = "blank_line"
 TAG_REGEX = re.compile(r"\{(ok)\}", re.I)
 
@@ -50,8 +49,7 @@ class LangEntity(LiteralEntity):
 
 
 class LangVisitor(NodeVisitor):
-    grammar = Grammar(
-        r"""
+    grammar = Grammar(r"""
         lang_file = (comment / entity / blank_line)*
 
         comment = "#"+ line_content line_ending
@@ -63,8 +61,7 @@ class LangVisitor(NodeVisitor):
         entity = string translation
         string = ";" line_content line_ending
         translation = line_content line_ending
-    """
-    )
+    """)
 
     def __init__(self, ctx):
         super().__init__()

--- a/contrib/lang/tests/test_parser.py
+++ b/contrib/lang/tests/test_parser.py
@@ -6,8 +6,7 @@ from parsimonious.exceptions import ParseError
 class TestLangParser(unittest.TestCase):
     def test_good(self):
         p = parser.getParser("foo.lang")
-        p.readUnicode(
-            """\
+        p.readUnicode("""\
 # Sample comment
 ;Source String
 Translated String
@@ -19,30 +18,25 @@ Translated Multiple Comments
 
 ;No Comments or Sources
 Translated No Comments or Sources
-"""
-        )
+""")
         msgs = p.parse()
         self.assertEqual(len(msgs), 3)
 
     def test_empty_translation(self):
         p = parser.getParser("foo.lang")
-        p.readUnicode(
-            """\
+        p.readUnicode("""\
 # Sample comment
 ;Source String
 
-"""
-        )
+""")
         msgs = p.parse()
         self.assertEqual(len(msgs), 1)
         self.assertIsInstance(msgs[0], parser.Junk)
 
     def test_bad(self):
         p = parser.getParser("foo.lang")
-        p.readUnicode(
-            """\
+        p.readUnicode("""\
 just garbage
-"""
-        )
+""")
         with self.assertRaises(ParseError):
             p.parse()


### PR DESCRIPTION
Removed 3.7 and 3.8 from CI. This was the error for 3.7:

```
Error: The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04.
```

Python 3.9–3.14 mimics the support we have in moz-l10n.

The other fixes are due to setuptools 81+ removing `pkg_resources`.

I kept a separate commit for the black reformatting.